### PR TITLE
mapChildren nullability issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,3 +53,7 @@ artifacts {
 sourceSets {
     main.java.srcDirs += 'src/main/kotlin'
 }
+
+test {
+    useTestNG()
+}

--- a/klaxon.iml
+++ b/klaxon.iml
@@ -16,10 +16,10 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:0.12.213" level="project" />
-    <orderEntry type="library" exported="" name="Gradle: org.jetbrains.kotlin:kotlin-runtime:0.12.213" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.beanshell:bsh:2.0b4" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: org.testng:testng:6.9.4" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.beanshell:bsh:2.0b4" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: com.beust:jcommander:1.48" level="project" />
+    <orderEntry type="library" exported="" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:0.12.1218" level="project" />
+    <orderEntry type="library" exported="" name="Gradle: org.jetbrains.kotlin:kotlin-runtime:0.12.1218" level="project" />
   </component>
 </module>

--- a/src/test/kotlin/com/beust/klaxon/KlaxonTest.kt
+++ b/src/test/kotlin/com/beust/klaxon/KlaxonTest.kt
@@ -4,6 +4,7 @@ import org.testng.annotations.BeforeClass
 import org.testng.annotations.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.fail
 
 class KlaxonTest {
     BeforeClass
@@ -235,6 +236,26 @@ class KlaxonTest {
         }
 
         assertEquals(1, j.lookup("a").single())
+    }
+
+    Test
+    fun mapChildren() {
+        val j = json {
+            array(1,2,3)
+        }
+
+        val result = j.mapChildrenObjectsOnly { fail("should never reach here") }
+        assertTrue(result.isEmpty())
+    }
+
+    Test
+    fun mapChildrenWithNulls() {
+        val j = json {
+            array(1,2,3)
+        }
+
+        val result = j.mapChildren { fail("should never reach here") }
+        assertEquals(listOf(null, null, null), result)
     }
 }
 


### PR DESCRIPTION
We have `mapChildren` nullability issue. 
In the original `mapChildren` declaration we have `<T>` that could be both `T` and `T?` and it only depends on `block` function return type so if we have `block` that returns non-nullable type then `mapChildren` will return JsonArray of non-nullable type too that is not true as we have `null` for non-object array elements.
Also notice that this nullability issue is not discovered by Kotlin M12 but in M13 nullability checks was improved and compilation fails with current master snapshot because of unsafety. 

This pull request provides fix: `mapChildren` now always returns nullable type and also there is `mapChildrenObjectsOnly` that skips non-object members and produces no nulls in the result JsonObject so returns non-nullable `T`

Notice it is a breaking change as mapChildren now returns `JsonArray<T?>` instead of `JsonArray<T>`
