### PR TITLE
Explicit generic types to fix compiler errors after updating Kotlin plugin to 4563

### DIFF
--- a/src/main/kotlin/com/beust/klaxon/DSL.kt
+++ b/src/main/kotlin/com/beust/klaxon/DSL.kt
@@ -57,10 +57,10 @@ public data class JsonObject(val map: MutableMap<String, Any?>) : JsonBase, Muta
 }
 
 public fun <T> JsonArray(vararg items : T) : JsonArray<T> =
-    JsonArray(ArrayList(Arrays.asList(*items)))
+    JsonArray<T>(ArrayList(Arrays.asList(*items)))
 
 public fun <T> JsonArray(list : List<T> = emptyList()) : JsonArray<T> =
-        JsonArray(list.toArrayList())
+        JsonArray<T>(list.toArrayList())
 
 public data class JsonArray<T>(val value : MutableList<T>) : JsonBase, MutableList<T> by value {
 

--- a/src/main/kotlin/com/beust/klaxon/Lookup.kt
+++ b/src/main/kotlin/com/beust/klaxon/Lookup.kt
@@ -35,17 +35,17 @@ public fun JsonArray<*>.bigInt(id: String) : JsonArray<BigInteger?> = mapChildre
 public fun JsonArray<*>.double(id: String) : JsonArray<Double?> = mapChildren { it.double(id) }
 
 public fun <T> JsonArray<*>.mapChildrenObjectsOnly(block : (JsonObject) -> T) : JsonArray<T> =
-        JsonArray(flatMapTo(ArrayList(size)) {
-            if (it is JsonObject) listOf(block(it))
+        JsonArray<T>(flatMapTo(ArrayList<T>(size)) {
+            if (it is JsonObject) listOf<T>(block(it))
             else if (it is JsonArray<*>) it.mapChildrenObjectsOnly(block)
             else listOf()
         })
 
 public fun <T : Any> JsonArray<*>.mapChildren(block : (JsonObject) -> T?) : JsonArray<T?> =
-        JsonArray(flatMapTo(ArrayList(size)) {
-            if (it is JsonObject) listOf(block(it))
+        JsonArray<T?>(flatMapTo(ArrayList<T?>(size)) {
+            if (it is JsonObject) listOf<T?>(block(it))
             else if (it is JsonArray<*>) it.mapChildren(block)
-            else listOf(null)
+            else listOf<T?>(null)
         })
 
 operator public fun JsonArray<*>.get(key : String) : JsonArray<Any?> = mapChildren { it[key] }


### PR DESCRIPTION
After updating to Kotlin 1.0.0-beta-4563, I began getting compiler
errors in Klaxon. I never really understood what the errors meant
exactly, but they were related to failed type inferences. I added a
couple explicit generic types, and made the errors go away. However,
I'd review the changes carefully because I just kept blindly adding
explicit generic types until the errors went away. Also note, the
compiler seems to silently succeed building a project after updating
Kotlin if you don't clean build caches.