### PR TITLE
Update to beta4 4584

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ local.properties
 build
 .idea
 .gradle
+.kobalt
 kobaltBuild
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import com.beust.kobalt.plugin.packaging.Jar
-
 buildscript {
     ext.kotlinVersion = '1.0.0-beta-2423'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.0.0-beta-2423'
+    ext.kotlinVersion = '1.0.0-beta-4584'
 
     repositories {
         mavenCentral()
@@ -37,6 +37,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     testCompile 'org.testng:testng:6.9.9'
+    testCompile "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
 }
 
 task sourceJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
     id "com.jfrog.bintray" version "1.2"
 }
 
-version = '0.20'
+version = '0.21'
 
 apply plugin: 'java'
 apply plugin: 'kotlin'

--- a/kobalt/src/Build.kt
+++ b/kobalt/src/Build.kt
@@ -12,6 +12,7 @@ val project = kotlinProject {
 
     dependenciesTest {
         compile("org.testng:testng:6.9.9")
+        compile("org.jetbrains.kotlin:kotlin-test:1.0.0-beta-4584")
     }
 
     assemble {

--- a/kobalt/src/Build.kt
+++ b/kobalt/src/Build.kt
@@ -8,7 +8,7 @@ val project = kotlinProject {
     name = "klaxon"
     group = "com.beust"
     artifactId = name
-    version = "0.20"
+    version = "0.21"
 
     dependenciesTest {
         compile("org.testng:testng:6.9.9")

--- a/kobalt/wrapper/kobalt-wrapper.properties
+++ b/kobalt/wrapper/kobalt-wrapper.properties
@@ -1,1 +1,1 @@
-kobalt.version=0.335
+kobalt.version=0.369


### PR DESCRIPTION
This PR updates:
- kotlin to beta4 (4584)
- kobalt to 0.369
- .gitignore to ignore .kobalt folder
- klaxon version to 0.21

Could you push the update to jcenter?
Thanks