### PR TITLE
Fix Unicode support

### DIFF
--- a/src/test/kotlin/com/beust/klaxon/TestLexerInputSize.kt
+++ b/src/test/kotlin/com/beust/klaxon/TestLexerInputSize.kt
@@ -1,0 +1,33 @@
+package com.beust.klaxon
+
+import org.testng.annotations.Test
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.io.SequenceInputStream
+import kotlin.test.assertEquals
+
+@Test
+class TestLexerInputSize {
+    @Test
+    fun testInputNotReadFully() {
+        var read = 0
+        val PREFIX = "{\"a\":\""
+        val first = ByteArrayInputStream(PREFIX.toByteArray(Charsets.UTF_8))
+        val second: InputStream = object : InputStream() {
+            var i = 40
+            override fun read(): Int {
+                if (i == -1) i++
+                read++
+                if (read > 2 * DEFAULT_BUFFER_SIZE) {
+                    throw AssertionError("Was read ($read) more than expected (2 * DEFAULT_BUFFER_SIZE($DEFAULT_BUFFER_SIZE)) bytes")
+                }
+                return i++
+            }
+        }
+        try {
+            Parser().parse(SequenceInputStream(first, second)) as JsonObject
+        } catch (e: RuntimeException) {
+            assertEquals("Unexpected character at position 259: '# (35)'", e.message)
+        }
+    }
+}

--- a/src/test/kotlin/com/beust/klaxon/TestRFC7159.kt
+++ b/src/test/kotlin/com/beust/klaxon/TestRFC7159.kt
@@ -77,6 +77,10 @@ class TestRFC7159 {
         jsonEquals("{ \"a\":\"hp://foo\"}", "{\"a\":\"hp://foo\"}")
     }
 
+    fun unicodeUnescaped() {
+        jsonEquals("{\"a\":\"ú\"}", "{\"a\":\"ú\"}")
+    }
+
     fun objectNullValue() {
         jsonEquals("{ \"a\":null}", "{\"a\":null}")
     }

--- a/src/test/kotlin/com/beust/klaxon/TestTypes.kt
+++ b/src/test/kotlin/com/beust/klaxon/TestTypes.kt
@@ -3,6 +3,7 @@ package com.beust.klaxon;
 import org.testng.annotations.Test
 import java.math.BigInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 @Test
 class TestTypes {
@@ -50,6 +51,15 @@ class TestTypes {
     fun typeUnicode(){
         val j = getJsonObject()
         assertEquals("foo\u20ffbar", j.string("unicode_value"))
+    }
+
+    fun typeUnescapedUnicode(){
+        val j = getJsonObject()
+        val actual = j.string("unicode_unescaped_value")
+        assertNotNull(actual)
+        assertEquals(0x00FA, actual!![0].toInt())
+        assertEquals(0x00FA, actual[1].toInt())
+        assertEquals("úú", actual)
     }
 
     fun typeEscape(){

--- a/src/test/resources/types.json
+++ b/src/test/resources/types.json
@@ -7,6 +7,7 @@
     "double_exp_value": 3.141E-10,
     "string_value": "foo-bar",
     "unicode_value": "foo\u20ffbar",
+    "unicode_unescaped_value": "ú\u00fa",
     "escape_value": "[\"|\\|\/|\b|\f|\n|\r|\t]",
     "object_value": {},
     "array_value": [],


### PR DESCRIPTION
Also some improvements in Lexer:
 * support Charset selection;
 * do not read all input fully into memory;
 * fix Unicode characters parsing.

Contains fix for #19 
