### PR TITLE
Add support for `java.io.Raeder` in Parser API

### DIFF
--- a/src/main/kotlin/com/beust/klaxon/Lexer.kt
+++ b/src/main/kotlin/com/beust/klaxon/Lexer.kt
@@ -1,6 +1,7 @@
 package com.beust.klaxon
 
 import java.io.InputStream
+import java.io.Reader
 import java.nio.charset.Charset
 import java.util.regex.Pattern
 
@@ -23,7 +24,9 @@ class Token(val tokenType: Type, val value: Any?) {
     }
 }
 
-class Lexer(input: InputStream, charset: Charset = Charsets.UTF_8) {
+class Lexer(reader: Reader) {
+    constructor(stream: InputStream, charset: Charset = Charsets.UTF_8) : this(stream.reader(charset))
+
     val EOF = Token(Type.EOF, null)
     var index = 0
 
@@ -34,7 +37,7 @@ class Lexer(input: InputStream, charset: Charset = Charsets.UTF_8) {
         return c == ' ' || c == '\r' || c == '\n' || c == '\t'
     }
 
-    private val reader = input.buffered().reader(charset)
+    private val reader = reader.buffered()
     private var next: Char? = null
 
     private fun nextChar(): Char {

--- a/src/main/kotlin/com/beust/klaxon/Parser.kt
+++ b/src/main/kotlin/com/beust/klaxon/Parser.kt
@@ -1,9 +1,7 @@
 package com.beust.klaxon
 
-import java.io.ByteArrayInputStream
-import java.io.File
-import java.io.FileInputStream
-import java.io.InputStream
+import java.io.*
+import java.nio.charset.Charset
 import java.util.*
 
 class World(var status : Status) {
@@ -92,7 +90,7 @@ class Parser {
     }
 
     fun parse(rawValue: StringBuilder): Any? =
-        ByteArrayInputStream(rawValue.toString().toByteArray()).use {
+        StringReader(rawValue.toString()).use {
             parse(it)
         }
 
@@ -101,7 +99,13 @@ class Parser {
             parse(it)
         }
 
-    fun parse(inputStream : InputStream) : Any? {
+    fun parse(inputStream: InputStream, charset: Charset = Charsets.UTF_8): Any? {
+        (parse("my.json") as JsonObject).lookup<String?>("users.email")
+
+        return parse(inputStream.reader(charset))
+    }
+
+    fun parse(reader: Reader): Any? {
 
         val sm = StateMachine()
 
@@ -202,7 +206,7 @@ class Parser {
         })
         // else error
 
-        val lexer = Lexer(inputStream)
+        val lexer = Lexer(reader)
 
         var world = World(Status.INIT)
         do {


### PR DESCRIPTION
And also `charset` parameter added to `Parser#parse(InputStream)` so user would able to specify correct encoding if it's not UTF-8.