### PR TITLE
fixes list rendering

### DIFF
--- a/src/main/kotlin/com/beust/klaxon/Render.kt
+++ b/src/main/kotlin/com/beust/klaxon/Render.kt
@@ -40,7 +40,7 @@ tailrec fun renderValue(v: Any?, result: Appendable, prettyPrint: Boolean, level
                 result,
                 prettyPrint,
                 level)
-        is List<*> -> renderValue(JsonArray(v.map { it?.toString() }), result, prettyPrint, level)
+        is List<*> -> renderValue(JsonArray(v), result, prettyPrint, level)
         is Pair<*, *> -> renderValue(v.second, result.renderString(v.first.toString()).append(": "), prettyPrint, level)
         else -> result.append(v.toString())
     }

--- a/src/test/kotlin/com/beust/klaxon/KlaxonTest.kt
+++ b/src/test/kotlin/com/beust/klaxon/KlaxonTest.kt
@@ -267,4 +267,20 @@ class KlaxonTest {
         val result = j.mapChildren { fail("should never reach here") }
         assertKlaxonEquals(listOf(null, null, null), result)
     }
+
+    fun renderMap() {
+        val map = mapOf(
+            "a" to 1,
+            "b" to "x",
+            "c" to null
+        )
+
+        assertEquals(valueToString(map), "{\"a\":1,\"b\":\"x\",\"c\":null}")
+    }
+
+    fun renderList() {
+        val list = listOf(null, 1, true, false, "a")
+
+        assertEquals(valueToString(list), "[null,1,true,false,\"a\"]")
+    }
 }


### PR DESCRIPTION
**Issue**: klaxon automatically converts all members of a list to string

```kotlin
val input = listOf(null, 1, 2, 3)
valueToString(input)    // return ["null","1","2","3"] instead of [null,1,2,3]

```