### PR TITLE
Add canonical json output to toJsonString() method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.0.0'
+    ext.kotlinVersion = '1.1.3'
 
     repositories {
         mavenCentral()

--- a/src/main/kotlin/com/beust/klaxon/DSL.kt
+++ b/src/main/kotlin/com/beust/klaxon/DSL.kt
@@ -25,7 +25,7 @@ data class JsonObject(val map: MutableMap<String, Any?>) : JsonBase, MutableMap<
         result.append("{")
 
         var comma = false
-        for ((k, v) in map) {
+        for ((k, v) in map.toSortedMap()) {
             if (comma) {
                 result.append(",")
             } else {

--- a/src/test/kotlin/com/beust/klaxon/KlaxonTest.kt
+++ b/src/test/kotlin/com/beust/klaxon/KlaxonTest.kt
@@ -2,6 +2,7 @@ package com.beust.klaxon
 
 import org.testng.annotations.BeforeClass
 import org.testng.annotations.Test
+import java.util.regex.Pattern
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.test.fail
@@ -102,20 +103,31 @@ class KlaxonTest {
 
 	fun canonicalJsonObject() {
 		val j = json {
-			obj(
-				"c" to 1,
-				"a" to 2,
-				"b" to obj(
-					"e" to 1,
-					"d" to 2
-				)
-			)
-		}.toJsonString(false)
+            obj(
+                    "c" to 1,
+                    "a" to 2,
+                    "b" to obj(
+                            "e" to 1,
+                            "d" to 2
+                    )
+            )
+		}.toJsonString(canonical = true)
 		
 		val expected = """{"a":2,"b":{"d":2,"e":1},"c":1}"""
 		
 		assertEquals(j, expected)
 	}
+    
+    fun canonicalJsonNumber() {
+        val j = json {
+            obj(
+                    "d" to 123456789.123456789,
+                    "f" to 123456789.123456789f
+            )
+        }.toJsonString(canonical = true)
+        
+        assert(Pattern.matches("\\{(\"[a-z]+\":\\d\\.\\d+E\\d+(,|}\$))+", j))
+    }
     
     private fun trim(s: String) = s.replace("\n", "").replace("\r", "")
 

--- a/src/test/kotlin/com/beust/klaxon/KlaxonTest.kt
+++ b/src/test/kotlin/com/beust/klaxon/KlaxonTest.kt
@@ -100,6 +100,23 @@ class KlaxonTest {
         assertEquals(trim(actual), trim(expected))
     }
 
+	fun canonicalJsonObject() {
+		val j = json {
+			obj(
+				"c" to 1,
+				"a" to 2,
+				"b" to obj(
+					"e" to 1,
+					"d" to 2
+				)
+			)
+		}.toJsonString(false)
+		
+		val expected = """{"a":2,"b":{"d":2,"e":1},"c":1}"""
+		
+		assertEquals(j, expected)
+	}
+    
     private fun trim(s: String) = s.replace("\n", "").replace("\r", "")
 
     fun renderStringEscapes() {


### PR DESCRIPTION
As mentioned in #48, it would be cool to have canonical json, for example to use signatures over json that would otherwise be formatted different by every library used. [This ietf draft](https://www.ietf.org/archive/id/draft-staykov-hu-json-canonical-form-00.txt) elaborates more on canonical json.

I have implemented the canonical json as an opt-in in the `JsonBase.toJsonString()` method. The changes are:
 - If `canonical` is true, the value of `prettyPrint` is ignored because canonical json requires to remove all redundant whitespaces
 - If `canonical` is true, the map of every `JsonObject` is sorted before serialization
 - If `canonical` is true, doubles (and floats) are always formatted in scientific form, like `1.234E2` and never like `123.4`