### PR TITLE
correct a function name, improve readability. Also update/fixed bugs in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Values parsed from a valid JSON file can be of the following type:
 Since this is a JSON object, we parse it as follows:
 
 ```kotlin
-fun parse(name: String) : Any {
+fun parse(name: String) : Any? {
     val cls = Parser::class.java
-    cls.getResourceAsStream(name)?.let { inputStream ->
+    return cls.getResourceAsStream(name)?.let { inputStream ->
         return Parser().parse(inputStream)
     }
 }
@@ -195,7 +195,7 @@ All the grades over 75:
 println("=== All grades bigger than 75")
 val result = array.flatMap {
     it.obj("schoolResults")
-            ?.array(JsonObject(), "scores")?.filter {
+            ?.array<JsonObject>("scores")?.filter {
                 it.long("grade")!! > 75
             }!!
 }

--- a/src/main/kotlin/com/beust/klaxon/Render.kt
+++ b/src/main/kotlin/com/beust/klaxon/Render.kt
@@ -16,7 +16,7 @@ private fun <A: Appendable> A.renderString(s: String): A {
             '\b' -> append("\\b")
             '\u000c' -> append("\\f")
             else -> {
-                if(isPrintableUnicode(ch)){
+                if(isNotPrintableUnicode(ch)) {
                     append("\\u")
                     append(Integer.toHexString(ch.toInt()).padStart(4, '0'))
                 } else {
@@ -30,8 +30,10 @@ private fun <A: Appendable> A.renderString(s: String): A {
     return this
 }
 
-private fun isPrintableUnicode(c: Char) : Boolean = ((c >= '\u0000' && c <= '\u001F')
-        || (c >= '\u007F' && c <= '\u009F') || (c >= '\u2000' && c <= '\u20FF'))
+private fun isNotPrintableUnicode(c: Char): Boolean =
+    c in '\u0000'..'\u001F' ||
+    c in '\u007F'..'\u009F' ||
+    c in '\u2000'..'\u20FF'
 
 private val decimalFormat = DecimalFormat("0.0####E0##;-0.0####E0##")
 


### PR DESCRIPTION
1. correct a function name: `isPrintableUnicode()` -> `isNotPrintableUnicode()`
2. improve readability with kotlin operator `(c >= MIN && c <= MAX)` can be replaced with `c in MIN..MAX`