### PR TITLE
Recursive object binding in high level API.

### DIFF
--- a/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
+++ b/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
@@ -77,6 +77,22 @@ class DefaultConverter(private val klaxon: Klaxon) : Converter<Any> {
 
                 converter.fromJson(JsonValue(it, jv.property, klaxon))
             }
+            is JsonObject -> {
+                val jt = jv.property?.returnType?.javaType
+                when (jt) {
+                    is ParameterizedType -> {
+                        val cls = jt.actualTypeArguments[0] as Class<*>
+                        klaxon.fromJsonObject(value, cls, cls.kotlin)
+                    }
+                    is Class<*> -> {
+                        val cls = jv.property?.getter?.returnType?.javaType as Class<*>
+                        klaxon.fromJsonObject(value, cls, cls.kotlin)
+                    }
+                    else -> {
+                        throw KlaxonException("Don't know how to convert $value")
+                    }
+                }
+            }
             else -> {
                 throw KlaxonException("Don't know how to convert $value")
             }

--- a/src/test/kotlin/com/beust/klaxon/BindingTest.kt
+++ b/src/test/kotlin/com/beust/klaxon/BindingTest.kt
@@ -83,6 +83,29 @@ class BindingTest {
 
     fun compoundObject() {
         val result = Klaxon()
+                .parse<Deck1>("""
+        {
+          "cardCount": 2,
+          "card":
+            {"value" : 5,"suit" : "Hearts"}
+        }
+        """)
+
+        if (result != null) {
+            Assert.assertEquals(result.cardCount, 2)
+            val card = result.card
+            if (card != null) {
+                Assert.assertEquals(card, Card(5, "Hearts"))
+            } else {
+                Assert.fail("Should have received a non null card")
+            }
+        } else {
+            Assert.fail("Should have received a non null deck")
+        }
+    }
+
+    fun compoundObjectWithConverter() {
+        val result = Klaxon()
                 .converter(CARD_CONVERTER)
                 .parse<Deck1>("""
         {
@@ -111,6 +134,26 @@ class BindingTest {
     )
 
     fun compoundObjectWithArray() {
+        val result = Klaxon()
+                .parse<Deck2>("""
+        {
+          "cardCount": 2,
+          "cards": [
+            {"value" : 5, "suit" : "Hearts"},
+            {"value" : 8, "suit" : "Spades"},
+          ]
+        }
+    """)
+
+        if (result != null) {
+            Assert.assertEquals(result.cardCount, 2)
+            Assert.assertEquals(result.cards, listOf(Card(5, "Hearts"), Card(8, "Spades")))
+        } else {
+            Assert.fail("Should have received a non null deck")
+        }
+    }
+
+    fun compoundObjectWithArrayWithConverter() {
         val result = Klaxon()
                 .converter(CARD_CONVERTER)
                 .parse<Deck2>("""


### PR DESCRIPTION
The "convertValue" fun of DefaultConverter now converts JsonObjects using klaxon.fromJsonObject. Added tests for recursive object binding.

Since I'm new to Kotlin and not very experienced in Java, I hope everything is okay.
  
  