### PR TITLE
Compile -> implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.beust:klaxon:2.1.14'
+    implementation 'com.beust:klaxon:2.1.14'
 }
 ```
 


### PR DESCRIPTION
I get the following message

> Configuration 'compile' is obsolete and has been replaced with 'implementation'. It will be removed at the end of 2018

According to [this SO answer](https://stackoverflow.com/questions/44493378/whats-the-difference-between-implementation-and-compile-in-gradle), it's safe to replace for `implementation`