### PR TITLE
Float serialization

### DIFF
--- a/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
+++ b/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
@@ -43,7 +43,7 @@ class DefaultConverter(private val klaxon: Klaxon, private val allPaths: HashMap
 
         val result = when (value) {
             is String, is Enum<*> -> "\"" + Render.escapeString(value.toString()) + "\""
-            is Double, is Int, is Boolean, is Long -> value.toString()
+            is Double, is Float, is Int, is Boolean, is Long -> value.toString()
             is Collection<*> -> {
                 val elements = value.filterNotNull().map { klaxon.toJsonString(it) }
                 joinToString(elements, "[", "]")

--- a/src/test/kotlin/com/beust/klaxon/Serialization.kt
+++ b/src/test/kotlin/com/beust/klaxon/Serialization.kt
@@ -1,0 +1,62 @@
+package com.beust.klaxon
+
+import org.testng.annotations.Test
+import kotlin.test.assertEquals
+
+@Test
+class Serialization {
+    enum class Sause { ONION }
+    val klaxon = Klaxon()
+
+    private fun serializationTest(expected: String, actual: Any) {
+        val actualSerialization = klaxon.toJsonString(actual)
+        assertEquals(expected, actualSerialization)
+    }
+
+    @Test
+    fun int() {
+        serializationTest("1", 1)
+    }
+
+    @Test
+    fun float() {
+        serializationTest("0.55", 0.55f)
+    }
+
+    @Test
+    fun double() {
+        serializationTest("0.332", 0.332)
+    }
+
+    @Test
+    fun boolean() {
+        serializationTest("true", true)
+    }
+
+    @Test
+    fun long() {
+        serializationTest("200100", 200100L)
+    }
+
+    @Test
+    fun string() {
+        serializationTest("\"Onion Sauce !\"", "Onion Sauce !")
+    }
+
+    @Test
+    fun enum() {
+        serializationTest("\"ONION\"", Sause.ONION)
+    }
+
+    @Test
+    fun collection() {
+        val collection = listOf("mole", "ratty", "badger", "toad")
+        serializationTest("[\"mole\", \"ratty\", \"badger\", \"toad\"]", collection)
+    }
+
+    @Test
+    fun map() {
+        val map = mapOf(1 to "uno", 2 to "dos", 3 to "tres")
+        serializationTest("{\"1\": \"uno\", \"2\": \"dos\", \"3\": \"tres\"}", map)
+    }
+}

--- a/src/test/kotlin/com/beust/klaxon/SerializationTest.kt
+++ b/src/test/kotlin/com/beust/klaxon/SerializationTest.kt
@@ -4,7 +4,7 @@ import org.testng.annotations.Test
 import kotlin.test.assertEquals
 
 @Test
-class Serialization {
+class SerializationTest {
     enum class Sause { ONION }
     val klaxon = Klaxon()
 


### PR DESCRIPTION
Hello ! 

Apparently, I found a bug in Float serialization.
I use _data class_ in my code to store _Settings_ with Float variables inside. For example consider the following: 
```
data class Settings(val text: String, val volume: Float)
```
Then I write my _Settings_ object with _Klaxon_, and read it. While reading the file I get an exception: _"Couldn't find a suitable constructor <...>: java.lang.IllegalArgumentException argument type mismatch"_. With Doubles instead of Floats it's work like a charm.

Here is code snippet:
```
val settings = Settings("ducks", 0.55f)
val klaxon = Klaxon()

val jsonString = klaxon.toJsonString(settings)
// "{"text" : "ducks", "volume": "0.55f"}"
val jsonObject = klaxon.parse<Settings>(jsonString)
// Exception here
```

From what I understood debugging this code, it was because of Float serialization. in `DefaultConverter.kt`, there is `toJson(...)` function in which was the bug. All number-like types serialization was casting to String, while Float (which wasn't there) was processed as `""""$value""""`.
I've added the `is Float` to the number-like serialization to fix this. 