### PR TITLE
Change default value for anotation name parameter

### DIFF
--- a/src/main/java/com/beust/klaxon/Json.kt
+++ b/src/main/java/com/beust/klaxon/Json.kt
@@ -1,5 +1,8 @@
 package com.beust.klaxon
 
+// While this is a valid JSON key name, it is unlikely to actually be used.
+const val NAME_NOT_INITIALIZED = "Klaxon:This field was not initialized!@#$%^&*()_+AIS8X9A4NT"
+
 // Commented VALUE_PARAMETER because of https://youtrack.jetbrains.com/issue/KT-23229
 @Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.CONSTRUCTOR
     // AnnotationTarget.VALUE_PARAMETER,
@@ -9,7 +12,7 @@ annotation class Json(
     /**
      * Used to map Kotlin properties and JSON fields that have different names.
      */
-    val name: String = "",
+    val name: String = NAME_NOT_INITIALIZED,
 
     /**
      * If true, the property will be ignored by Klaxon.
@@ -21,3 +24,5 @@ annotation class Json(
      */
     val path: String = ""
 )
+
+fun Json.nameInitialized() = this.name != NAME_NOT_INITIALIZED

--- a/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
+++ b/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
@@ -63,9 +63,9 @@ class DefaultConverter(private val klaxon: Klaxon, private val allPaths: HashMap
                     properties.forEach { prop ->
                         prop.getter.call(value)?.let { getValue ->
                             val jsonValue = klaxon.toJsonString(getValue)
-                            val jsonFieldName = Annotations.findJsonAnnotation(value::class, prop.name)?.name
+                            val jsonField = Annotations.findJsonAnnotation(value::class, prop.name)
                             val fieldName =
-                                    if (jsonFieldName != null && jsonFieldName != "") jsonFieldName
+                                    if (jsonField != null && jsonField.nameInitialized()) jsonField.name
                                     else prop.name
                             valueList.add("\"$fieldName\" : $jsonValue")
                         }

--- a/src/main/kotlin/com/beust/klaxon/JsonObjectConverter.kt
+++ b/src/main/kotlin/com/beust/klaxon/JsonObjectConverter.kt
@@ -91,7 +91,7 @@ class JsonObjectConverter(private val klaxon: Klaxon, private val allPaths: Hash
             val prop = kc.memberProperties.first { it.name == thisProp.name }
             val jsonAnnotation = Annotations.findJsonAnnotation(kc, prop.name)
             val fieldName =
-                    if (jsonAnnotation != null && jsonAnnotation.name != "") jsonAnnotation.name
+                    if (jsonAnnotation != null && jsonAnnotation.nameInitialized()) jsonAnnotation.name
                     else prop.name
             val path = if (jsonAnnotation?.path != "") jsonAnnotation?.path else null
 

--- a/src/test/kotlin/com/beust/klaxon/ParseFromEmptyNameTest.kt
+++ b/src/test/kotlin/com/beust/klaxon/ParseFromEmptyNameTest.kt
@@ -1,0 +1,29 @@
+package com.beust.klaxon
+
+import org.testng.Assert
+import org.testng.annotations.Test
+
+@Test
+class ParseFromEmptyNameTest {
+
+    fun nameSetToEmptyString() {
+        data class EmptyName (
+                @Json(name = "")
+                val empty: String)
+        val sampleJson = """{"":"value"}"""
+        val result = Klaxon().parse<EmptyName>(sampleJson)
+
+        Assert.assertNotNull(result)
+        Assert.assertEquals(result!!.empty, "value")
+    }
+
+    fun nameSetToDefaultValue() {
+        data class SpecificName (
+                @Json(name = NAME_NOT_INITIALIZED)
+                val oddName: String)
+        val sampleJson = """{"$NAME_NOT_INITIALIZED":"value"}"""
+        Assert.assertThrows(KlaxonException::class.java) {
+            Klaxon().parse<SpecificName>(sampleJson)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #146 

Technically, this is no different from empty string. It is still a valid JSON key that could theoretically be used. However, it is significant less likely to be used.