### PR TITLE
Fixed streaming nested JSON objects

### DIFF
--- a/src/main/kotlin/com/beust/klaxon/Parser.kt
+++ b/src/main/kotlin/com/beust/klaxon/Parser.kt
@@ -37,14 +37,17 @@ class Parser(private val pathMatchers: List<PathMatcher> = emptyList(),
         val lexer = passedLexer ?: Lexer(reader)
 
         var world = World(Status.INIT, pathMatchers)
+        var wasNested: Boolean
         if (lexer.peek().tokenType == TokenType.COMMA) lexer.nextToken()
         do {
             val token = lexer.nextToken()
             log("Token: $token")
+            wasNested = world.isNestedStatus()
             world = sm.next(world, token)
-        } while (token.tokenType != TokenType.RIGHT_BRACE
-                && token.tokenType != TokenType.RIGHT_BRACKET
-                && token.tokenType != TokenType.EOF
+        } while (wasNested || (token.tokenType != TokenType.RIGHT_BRACE
+                        && token.tokenType != TokenType.RIGHT_BRACKET
+                        && token.tokenType != TokenType.EOF
+                        )
         )
 
         return world.popValue()

--- a/src/main/kotlin/com/beust/klaxon/World.kt
+++ b/src/main/kotlin/com/beust/klaxon/World.kt
@@ -80,6 +80,10 @@ class World(var status : Status, val pathMatchers: List<PathMatcher> = emptyList
         return statusStack[0]
     }
 
+    fun isNestedStatus() : Boolean {
+        return statusStack.size > 1
+    }
+
     fun hasValues() : Boolean {
         return valueStack.size > 1
     }

--- a/src/test/kotlin/com/beust/klaxon/StreamingTest.kt
+++ b/src/test/kotlin/com/beust/klaxon/StreamingTest.kt
@@ -76,6 +76,26 @@ class StreamingTest {
         }
     }
 
+    data class Address(val street: String)
+    data class Person2(val name: String, val address:Address)
+    fun nestedObjects() {
+        val objectString = """[
+            { "name": "Joe", "address": { "street": "Klaxon Road" }}
+        ]""".trimIndent()
+
+        val klaxon = Klaxon()
+        JsonReader(StringReader(objectString)).use { reader ->
+            val result = arrayListOf<Person2>()
+            reader.beginArray {
+                while (reader.hasNext()){
+                    val person = klaxon.parse<Person2>(reader)
+                    result.add(person!!)
+                }
+            }
+            Assert.assertEquals(result.get(0), Person2("Joe", Address("Klaxon Road")))
+        }
+    }
+
     val arrayInObject = """{ "array": [
             { "name": "Joe", "age": 23 },
             { "name": "Jill", "age": 35 }


### PR DESCRIPTION
I found a bug where nested JSON objects in a stream would not be parsed correctly. The parser would stop on the first RIGHT_BRACE (which is from the inner object) ignoring the rest of the object.

I've created a unit test to show the problem and introduced a way to see if World's status is nested.