### PR TITLE
Improve the readability of the output of the gradle and travis logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ jdk:
 
 install: true
 
-script: ./gradlew check
+script: ./gradlew check --console=plain
 #script: ./kobaltw --noIncrementalKotlin test
 

--- a/klaxon-root.gradle.kts
+++ b/klaxon-root.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
 buildscript {
     repositories {
         mavenCentral()
@@ -58,6 +61,15 @@ configure(sourceProjects) {
 
     tasks.withType<Test>().configureEach {
         useTestNG()
+
+        testLogging {
+            events(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.STARTED)
+            displayGranularity = 0
+            showExceptions = true
+            showCauses = true
+            showStackTraces = true
+            exceptionFormat = TestExceptionFormat.FULL
+        }
     }
 }
 


### PR DESCRIPTION
This doesn't actually fix the tests, this just improves logging in travis and when running the gradle tests.