### PR TITLE
Change Token to sealed class. Simplify all uses of Tokens

### DIFF
--- a/klaxon/src/main/kotlin/com/beust/klaxon/JsonReader.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/JsonReader.kt
@@ -100,7 +100,7 @@ class JsonReader(val reader: Reader) : Reader() {
     fun nextName(): String {
         skip()
         val next = lexer.nextToken()
-        if (next !is Value || next.value !is String) {
+        if (next !is Value<*> || next.value !is String) {
             throw KlaxonException("Expected a name but got $next")
         }
         return next.value
@@ -145,10 +145,10 @@ class JsonReader(val reader: Reader) : Reader() {
 
     val lexer = Lexer(reader)
 
-    private inline fun <reified T : Token<*>> consumeToken() {
+    private inline fun <reified T : Token> consumeToken() {
         val next = lexer.nextToken()
         if (next !is T) {
-            throw KlaxonException("Expected a ${T::class.java.simpleName} but read $next")
+            throw KlaxonException("Expected a ${T::class.objectInstance.toString()} but read $next")
         }
     }
 
@@ -167,7 +167,7 @@ class JsonReader(val reader: Reader) : Reader() {
         skip()
 
         val next = lexer.nextToken()
-        if (next !is Value) {
+        if (next !is Value<*>) {
             throw KlaxonException("Expected a value but got $next")
         }
         return next.value

--- a/klaxon/src/main/kotlin/com/beust/klaxon/JsonReader.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/JsonReader.kt
@@ -1,5 +1,6 @@
 package com.beust.klaxon
 
+import com.beust.klaxon.token.*
 import java.io.Reader
 import java.math.BigInteger
 
@@ -11,17 +12,13 @@ class JsonReader(val reader: Reader) : Reader() {
      * @return the next String.
      * @throws JsonParsingException the next value is not a String.
      */
-    fun nextString() = consumeValue { value ->
-        value as? String ?: throw JsonParsingException("Next token is not a string: $value")
-    }
+    fun nextString() = consumeValue<String>()
 
     /**
      * @return the next Int.
      * @throws JsonParsingException the next value is not an Int.
      */
-    fun nextInt() = consumeValue { value ->
-        value as? Int ?: throw JsonParsingException("Next token is not a int: $value")
-    }
+    fun nextInt() = consumeValue<Int>()
 
     /**
      * @return the next Long (upscaling as needed).
@@ -64,9 +61,7 @@ class JsonReader(val reader: Reader) : Reader() {
      * @return the next boolean.
      * @throws JsonParsingException the next value is not a Boolean.
      */
-    fun nextBoolean() = consumeValue { value ->
-        value as? Boolean ?: throw JsonParsingException("Next token is not a boolean: $value")
-    }
+    fun nextBoolean() = consumeValue<Boolean>()
 
     /**
      * @return the next object, making sure the current token is an open brace and the last token is a closing brace.
@@ -76,7 +71,7 @@ class JsonReader(val reader: Reader) : Reader() {
             JsonObject().let { result ->
                 while (hasNext()) {
                     val name = nextName()
-                    val value = consumeValue { value -> value }
+                    val value = consumeValue<Any?>()
                     result[name] = value
                 }
                 result
@@ -91,12 +86,8 @@ class JsonReader(val reader: Reader) : Reader() {
         return beginArray {
             arrayListOf<Any>().let { result ->
                 while (hasNext()) {
-                    val v = consumeValue { value -> value }
-                    if (v != null) {
-                        result.add(v)
-                    } else {
-                        throw KlaxonException("Couldn't parse")
-                    }
+                    val v = consumeValue<Any?>()
+                    v?.let { result.add(it) } ?: throw KlaxonException("Couldn't parse")
                 }
                 result
             }
@@ -109,11 +100,10 @@ class JsonReader(val reader: Reader) : Reader() {
     fun nextName(): String {
         skip()
         val next = lexer.nextToken()
-        if (next.tokenType == TokenType.VALUE) {
-            return next.value.toString()
-        } else {
+        if (next !is Value || next.value !is String) {
             throw KlaxonException("Expected a name but got $next")
         }
+        return next.value
     }
 
     /**
@@ -143,7 +133,7 @@ class JsonReader(val reader: Reader) : Reader() {
     /**
      * @return true if this reader has more tokens to read before finishing the current object/array.
      */
-    fun hasNext(): Boolean = lexer.peek().tokenType.let { it != TokenType.RIGHT_BRACKET && it != TokenType.RIGHT_BRACE }
+    fun hasNext(): Boolean = lexer.peek().let { it !is RIGHT_BRACKET && it !is RIGHT_BRACE }
 
     override fun close() {
         reader.close()
@@ -155,33 +145,44 @@ class JsonReader(val reader: Reader) : Reader() {
 
     val lexer = Lexer(reader)
 
-    private fun consumeToken(type: TokenType, expected: String) {
+    private inline fun <reified T : Token<*>> consumeToken() {
         val next = lexer.nextToken()
-        if (next.tokenType != type) {
-            throw KlaxonException("Expected a $expected but read $next")
+        if (next !is T) {
+            throw KlaxonException("Expected a ${T::class.java.simpleName} but read $next")
         }
     }
 
-    private fun privateBeginArray() = consumeToken(TokenType.LEFT_BRACKET, "[")
-    private fun privateEndArray() = consumeToken(TokenType.RIGHT_BRACKET, "]")
+    private fun privateBeginArray() = consumeToken<LEFT_BRACKET>()
+    private fun privateEndArray() = consumeToken<RIGHT_BRACKET>()
 
-    private fun privateBeginObject() = consumeToken(TokenType.LEFT_BRACE, "{")
-    private fun privateEndObject() = consumeToken(TokenType.RIGHT_BRACE, "}")
+    private fun privateBeginObject() = consumeToken<LEFT_BRACE>()
+    private fun privateEndObject() = consumeToken<RIGHT_BRACE>()
 
-    private val SKIPS = setOf(TokenType.COLON, TokenType.COMMA)
+    private val SKIPS = setOf(COLON, COMMA)
     private fun skip() {
-        while (SKIPS.contains(lexer.peek().tokenType)) lexer.nextToken()
+        while (SKIPS.contains(lexer.peek())) lexer.nextToken()
     }
 
-    private fun <T> consumeValue(convert: (Any?) -> T): T {
+    private fun nextValue(): Any? {
         skip()
 
         val next = lexer.nextToken()
-        if (next.tokenType == TokenType.VALUE) {
-            return convert(next.value)
-        } else {
-            throw KlaxonException("Expected a name but got $next")
+        if (next !is Value) {
+            throw KlaxonException("Expected a value but got $next")
         }
+        return next.value
     }
 
+    private fun <T> consumeValue(convert: (Any?) -> T): T {
+        return convert(nextValue())
+    }
+
+    /**
+     * Convenience method for consuming a primitive value as is (without any conversion needed).
+     */
+    private inline fun <reified T> consumeValue(): T {
+        val value = nextValue()
+        return value as? T
+            ?: throw JsonParsingException("Next token is not a ${T::class.java.simpleName}: $value")
+    }
 }

--- a/klaxon/src/main/kotlin/com/beust/klaxon/KlaxonParser.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/KlaxonParser.kt
@@ -76,24 +76,24 @@ internal class KlaxonParser(
         with(stateMachine) {
             put(
                 Status.INIT,
-                VALUE_TYPE.tokenType, { world: World, token: Token<*> ->
-                world.pushAndSet(Status.IN_FINISHED_VALUE, token.value!!)
+                VALUE_TYPE.tokenType, { world: World, token: Token ->
+                world.pushAndSet(Status.IN_FINISHED_VALUE, (token as Value<*>).value!!)
             })
             put(
                 Status.INIT,
-                LEFT_BRACE.tokenType, { world: World, _: Token<*> ->
+                LEFT_BRACE.tokenType, { world: World, _: Token ->
                 world.pushAndSet(Status.IN_OBJECT, JsonObject())
             })
             put(
                 Status.INIT,
-                LEFT_BRACKET.tokenType, { world: World, _: Token<*> ->
+                LEFT_BRACKET.tokenType, { world: World, _: Token ->
                 world.pushAndSet(Status.IN_ARRAY, JsonArray<Any>())
             })
             // else error
 
             put(
                 Status.IN_FINISHED_VALUE,
-                EOF.tokenType, { world: World, _: Token<*> ->
+                EOF.tokenType, { world: World, _: Token ->
                 world.result = world.popValue()
                 world
             })
@@ -101,18 +101,18 @@ internal class KlaxonParser(
 
             put(
                 Status.IN_OBJECT,
-                COMMA.tokenType, { world: World, _: Token<*> ->
+                COMMA.tokenType, { world: World, _: Token ->
                 world.foundValue()
                 world
             })
             put(
                 Status.IN_OBJECT,
-                VALUE_TYPE.tokenType, { world: World, token: Token<*> ->
-                world.pushAndSet(Status.PASSED_PAIR_KEY, token.value!!)
+                VALUE_TYPE.tokenType, { world: World, token: Token ->
+                world.pushAndSet(Status.PASSED_PAIR_KEY, (token as Value<*>).value!!)
             })
             put(
                 Status.IN_OBJECT,
-                RIGHT_BRACE.tokenType, { world: World, _: Token<*> ->
+                RIGHT_BRACE.tokenType, { world: World, _: Token ->
                 world.foundValue()
                 with(world) {
                     status = if (hasValues()) {
@@ -128,24 +128,24 @@ internal class KlaxonParser(
 
             put(
                 Status.PASSED_PAIR_KEY,
-                COLON.tokenType, { world: World, _: Token<*> ->
+                COLON.tokenType, { world: World, _: Token ->
                 world
             })
             put(
                 Status.PASSED_PAIR_KEY,
-                VALUE_TYPE.tokenType, { world: World, token: Token<*> ->
+                VALUE_TYPE.tokenType, { world: World, token: Token ->
                 with(world) {
                     popStatus()
                     val key = popValue() as String
                     parent = getFirstObject()
-                    parent[key] = token.value
+                    parent[key] = (token as Value<*>).value
                     status = peekStatus()
                     this
                 }
             })
             put(
                 Status.PASSED_PAIR_KEY,
-                LEFT_BRACKET.tokenType, { world: World, _: Token<*> ->
+                LEFT_BRACKET.tokenType, { world: World, _: Token ->
                 with(world) {
                     popStatus()
                     val key = popValue() as String
@@ -157,7 +157,7 @@ internal class KlaxonParser(
             })
             put(
                 Status.PASSED_PAIR_KEY,
-                LEFT_BRACE.tokenType, { world: World, _: Token<*> ->
+                LEFT_BRACE.tokenType, { world: World, _: Token ->
                 with(world) {
                     popStatus()
                     val key = popValue() as String
@@ -171,19 +171,19 @@ internal class KlaxonParser(
 
             put(
                 Status.IN_ARRAY,
-                COMMA.tokenType, { world: World, _: Token<*> ->
+                COMMA.tokenType, { world: World, _: Token ->
                 world
             })
             put(
                 Status.IN_ARRAY,
-                VALUE_TYPE.tokenType, { world: World, token: Token<*> ->
+                VALUE_TYPE.tokenType, { world: World, token: Token ->
                 val value = world.getFirstArray()
-                value.add(token.value)
+                value.add((token as Value<*>).value)
                 world
             })
             put(
                 Status.IN_ARRAY,
-                RIGHT_BRACKET.tokenType, { world: World, _: Token<*> ->
+                RIGHT_BRACKET.tokenType, { world: World, _: Token ->
                 world.foundValue()
                 with(world) {
                     status = if (hasValues()) {
@@ -198,7 +198,7 @@ internal class KlaxonParser(
             })
             put(
                 Status.IN_ARRAY,
-                LEFT_BRACE.tokenType, { world: World, _: Token<*> ->
+                LEFT_BRACE.tokenType, { world: World, _: Token ->
                 val value = world.getFirstArray()
                 val newObject = JsonObject()
                 value.add(newObject)
@@ -206,7 +206,7 @@ internal class KlaxonParser(
             })
             put(
                 Status.IN_ARRAY,
-                LEFT_BRACKET.tokenType, { world: World, _: Token<*> ->
+                LEFT_BRACKET.tokenType, { world: World, _: Token ->
                 val value = world.getFirstArray()
                 val newArray = JsonArray<Any>()
                 value.add(newArray)

--- a/klaxon/src/main/kotlin/com/beust/klaxon/KlaxonParser.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/KlaxonParser.kt
@@ -1,5 +1,6 @@
 package com.beust.klaxon
 
+import com.beust.klaxon.token.*
 import java.io.InputStream
 import java.io.Reader
 import java.io.StringReader
@@ -32,15 +33,15 @@ internal class KlaxonParser(
 
         var world = World(Status.INIT, pathMatchers)
         var wasNested: Boolean
-        if (lexer.peek().tokenType == TokenType.COMMA) lexer.nextToken()
+        if (lexer.peek() is COMMA) lexer.nextToken()
         do {
             val token = lexer.nextToken()
             log("Token: $token")
             wasNested = world.isNestedStatus()
             world = sm.next(world, token)
-        } while (wasNested || (token.tokenType != TokenType.RIGHT_BRACE &&
-                token.tokenType != TokenType.RIGHT_BRACKET &&
-                token.tokenType != TokenType.EOF
+        } while (wasNested || (token !is RIGHT_BRACE &&
+                token !is RIGHT_BRACKET &&
+                token !is EOF
                 )
         )
 
@@ -60,7 +61,7 @@ internal class KlaxonParser(
             world.index = lexer.index
             world.line = lexer.line
             world = sm.next(world, token)
-        } while (token.tokenType != TokenType.EOF)
+        } while (token !is EOF)
 
         return world.result!!
     }
@@ -75,24 +76,24 @@ internal class KlaxonParser(
         with(stateMachine) {
             put(
                 Status.INIT,
-                TokenType.VALUE, { world: World, token: Token ->
+                VALUE_TYPE.tokenType, { world: World, token: Token<*> ->
                 world.pushAndSet(Status.IN_FINISHED_VALUE, token.value!!)
             })
             put(
                 Status.INIT,
-                TokenType.LEFT_BRACE, { world: World, _: Token ->
+                LEFT_BRACE.tokenType, { world: World, _: Token<*> ->
                 world.pushAndSet(Status.IN_OBJECT, JsonObject())
             })
             put(
                 Status.INIT,
-                TokenType.LEFT_BRACKET, { world: World, _: Token ->
+                LEFT_BRACKET.tokenType, { world: World, _: Token<*> ->
                 world.pushAndSet(Status.IN_ARRAY, JsonArray<Any>())
             })
             // else error
 
             put(
                 Status.IN_FINISHED_VALUE,
-                TokenType.EOF, { world: World, _: Token ->
+                EOF.tokenType, { world: World, _: Token<*> ->
                 world.result = world.popValue()
                 world
             })
@@ -100,18 +101,18 @@ internal class KlaxonParser(
 
             put(
                 Status.IN_OBJECT,
-                TokenType.COMMA, { world: World, _: Token ->
+                COMMA.tokenType, { world: World, _: Token<*> ->
                 world.foundValue()
                 world
             })
             put(
                 Status.IN_OBJECT,
-                TokenType.VALUE, { world: World, token: Token ->
+                VALUE_TYPE.tokenType, { world: World, token: Token<*> ->
                 world.pushAndSet(Status.PASSED_PAIR_KEY, token.value!!)
             })
             put(
                 Status.IN_OBJECT,
-                TokenType.RIGHT_BRACE, { world: World, _: Token ->
+                RIGHT_BRACE.tokenType, { world: World, _: Token<*> ->
                 world.foundValue()
                 with(world) {
                     status = if (hasValues()) {
@@ -127,12 +128,12 @@ internal class KlaxonParser(
 
             put(
                 Status.PASSED_PAIR_KEY,
-                TokenType.COLON, { world: World, _: Token ->
+                COLON.tokenType, { world: World, _: Token<*> ->
                 world
             })
             put(
                 Status.PASSED_PAIR_KEY,
-                TokenType.VALUE, { world: World, token: Token ->
+                VALUE_TYPE.tokenType, { world: World, token: Token<*> ->
                 with(world) {
                     popStatus()
                     val key = popValue() as String
@@ -144,7 +145,7 @@ internal class KlaxonParser(
             })
             put(
                 Status.PASSED_PAIR_KEY,
-                TokenType.LEFT_BRACKET, { world: World, _: Token ->
+                LEFT_BRACKET.tokenType, { world: World, _: Token<*> ->
                 with(world) {
                     popStatus()
                     val key = popValue() as String
@@ -156,7 +157,7 @@ internal class KlaxonParser(
             })
             put(
                 Status.PASSED_PAIR_KEY,
-                TokenType.LEFT_BRACE, { world: World, _: Token ->
+                LEFT_BRACE.tokenType, { world: World, _: Token<*> ->
                 with(world) {
                     popStatus()
                     val key = popValue() as String
@@ -170,19 +171,19 @@ internal class KlaxonParser(
 
             put(
                 Status.IN_ARRAY,
-                TokenType.COMMA, { world: World, _: Token ->
+                COMMA.tokenType, { world: World, _: Token<*> ->
                 world
             })
             put(
                 Status.IN_ARRAY,
-                TokenType.VALUE, { world: World, token: Token ->
+                VALUE_TYPE.tokenType, { world: World, token: Token<*> ->
                 val value = world.getFirstArray()
                 value.add(token.value)
                 world
             })
             put(
                 Status.IN_ARRAY,
-                TokenType.RIGHT_BRACKET, { world: World, _: Token ->
+                RIGHT_BRACKET.tokenType, { world: World, _: Token<*> ->
                 world.foundValue()
                 with(world) {
                     status = if (hasValues()) {
@@ -197,7 +198,7 @@ internal class KlaxonParser(
             })
             put(
                 Status.IN_ARRAY,
-                TokenType.LEFT_BRACE, { world: World, _: Token ->
+                LEFT_BRACE.tokenType, { world: World, _: Token<*> ->
                 val value = world.getFirstArray()
                 val newObject = JsonObject()
                 value.add(newObject)
@@ -205,7 +206,7 @@ internal class KlaxonParser(
             })
             put(
                 Status.IN_ARRAY,
-                TokenType.LEFT_BRACKET, { world: World, _: Token ->
+                LEFT_BRACKET.tokenType, { world: World, _: Token<*> ->
                 val value = world.getFirstArray()
                 val newArray = JsonArray<Any>()
                 value.add(newArray)

--- a/klaxon/src/main/kotlin/com/beust/klaxon/Lexer.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/Lexer.kt
@@ -1,36 +1,13 @@
 package com.beust.klaxon
 
+import com.beust.klaxon.token.*
 import java.io.Reader
 import java.util.regex.Pattern
-
-enum class TokenType(val value: String) {
-    VALUE("a value"),
-    LEFT_BRACE("\"{\""),
-    RIGHT_BRACE("\"}\""),
-    LEFT_BRACKET("\"[\""),
-    RIGHT_BRACKET("\"]\""),
-    COMMA("\",\""),
-    COLON("\":\""),
-    EOF("EOF")
-}
-
-data class Token(val tokenType: TokenType, val value: Any? = null) {
-    override fun toString() : String {
-        val v =
-            if (value != null) {
-                " ($value)"
-            } else {
-                ""
-            }
-        return tokenType.toString() + v
-    }
-}
 
 /**
  * if `lenient` is true, names (the identifiers left of the colon) are allowed to not be surrounded by double quotes.
  */
-class Lexer(val passedReader: Reader, val lenient: Boolean = false): Iterator<Token> {
-    private val EOF = Token(TokenType.EOF, null)
+class Lexer(passedReader: Reader, val lenient: Boolean = false): Iterator<Token<*>> {
     var index = 0
     var line = 1
 
@@ -44,6 +21,8 @@ class Lexer(val passedReader: Reader, val lenient: Boolean = false): Iterator<To
 
     private val reader = passedReader.buffered()
     private var next: Char?
+    private val isDone: Boolean
+        get() = next == null
 
     init {
         val c = reader.read()
@@ -51,7 +30,7 @@ class Lexer(val passedReader: Reader, val lenient: Boolean = false): Iterator<To
     }
 
     private fun nextChar(): Char {
-        if (isDone()) throw IllegalStateException("Cannot get next char: EOF reached")
+        if (isDone) throw IllegalStateException("Cannot get next char: EOF reached")
         val c = next!!
         next = reader.read().let { if (it == -1) null else it.toChar() }
         index++
@@ -60,11 +39,9 @@ class Lexer(val passedReader: Reader, val lenient: Boolean = false): Iterator<To
     }
 
     private fun peekChar() : Char {
-        if (isDone()) throw IllegalStateException("Cannot peek next char: EOF reached")
+        if (isDone) throw IllegalStateException("Cannot peek next char: EOF reached")
         return next!!
     }
-
-    private fun isDone() : Boolean = next == null
 
     val BOOLEAN_LETTERS = "falsetrue".toSet()
     private fun isBooleanLetter(c: Char) : Boolean {
@@ -78,44 +55,33 @@ class Lexer(val passedReader: Reader, val lenient: Boolean = false): Iterator<To
                 || c in NULL_LETTERS
     }
 
-    private var peeked: Token? = null
+    private var peeked: Token<*>? = null
 
-    fun peek() : Token {
-        if (peeked == null) {
-            peeked = actualNextToken()
-        }
+    fun peek() : Token<*> {
+        peeked = peeked ?: actualNextToken()
         return peeked!!
     }
 
     override fun next() = nextToken()
-    override fun hasNext() = peek() != EOF
+    override fun hasNext() = peek() !is EOF
 
-    fun nextToken(): Token {
-        val result =
-            if (peeked != null) {
-                val r = peeked!!
-                peeked = null
-                r
-            } else {
-                actualNextToken()
-            }
-        return result
+    fun nextToken(): Token<*> {
+        return peeked?.also { peeked = null } ?: actualNextToken()
     }
 
     private var expectName = false
 
-    private fun actualNextToken() : Token {
+    private fun actualNextToken() : Token<*> {
 
-        if (isDone()) {
+        if (isDone) {
             return EOF
         }
 
-        val tokenType: TokenType
+        val token: Token<*>
         var c = nextChar()
         val currentValue = StringBuilder()
-        var jsonValue: Any? = null
 
-        while (! isDone() && isSpace(c)) {
+        while (!isDone && isSpace(c)) {
             c = nextChar()
         }
 
@@ -123,17 +89,16 @@ class Lexer(val passedReader: Reader, val lenient: Boolean = false): Iterator<To
             if (lenient) {
                 currentValue.append(c)
             }
-            tokenType = TokenType.VALUE
             loop@
             do {
-                if (isDone()) {
+                if (isDone) {
                     throw KlaxonException("Unterminated string")
                 }
 
                 c = if (lenient) peekChar() else nextChar()
                 when (c) {
                     '\\' -> {
-                        if (isDone()) {
+                        if (isDone) {
                             throw KlaxonException("Unterminated string")
                         }
 
@@ -170,7 +135,7 @@ class Lexer(val passedReader: Reader, val lenient: Boolean = false): Iterator<To
                                 break@loop
                             } else {
                                 currentValue.append(c)
-                                c = nextChar()
+                                nextChar()
                             }
                         } else {
                             currentValue.append(c)
@@ -178,26 +143,26 @@ class Lexer(val passedReader: Reader, val lenient: Boolean = false): Iterator<To
                 }
             } while (true)
 
-            jsonValue = currentValue.toString()
+            token = Value(currentValue.toString())
         } else if ('{' == c) {
-            tokenType = TokenType.LEFT_BRACE
+            token = LEFT_BRACE
             expectName = true
         } else if ('}' == c) {
-            tokenType = TokenType.RIGHT_BRACE
+            token = RIGHT_BRACE
             expectName = false
         } else if ('[' == c) {
-            tokenType = TokenType.LEFT_BRACKET
+            token = LEFT_BRACKET
             expectName = false
         } else if (']' == c) {
-            tokenType = TokenType.RIGHT_BRACKET
+            token = RIGHT_BRACKET
             expectName = false
         } else if (':' == c) {
-            tokenType = TokenType.COLON
+            token = COLON
             expectName = false
         } else if (',' == c) {
-            tokenType = TokenType.COMMA
+            token = COMMA
             expectName = true
-        } else if (! isDone()) {
+        } else if (!isDone) {
             while (isValueLetter(c)) {
                 currentValue.append(c)
                 if (! isValueLetter(peekChar())) {
@@ -208,35 +173,35 @@ class Lexer(val passedReader: Reader, val lenient: Boolean = false): Iterator<To
             }
             val v = currentValue.toString()
             if (NUMERIC.matcher(v).matches()) {
-                try {
-                    jsonValue = java.lang.Integer.parseInt(v)
+                token = try {
+                    Value(java.lang.Integer.parseInt(v))
                 } catch (e: NumberFormatException){
                     try {
-                        jsonValue = java.lang.Long.parseLong(v)
+                        Value(java.lang.Long.parseLong(v))
                     } catch(e: NumberFormatException) {
-                        jsonValue = java.math.BigInteger(v)
+                        Value(java.math.BigInteger(v))
                     }
                 }
             } else if (DOUBLE.matcher(v).matches()) {
-                jsonValue = java.lang.Double.parseDouble(v)
+                token = Value(java.lang.Double.parseDouble(v))
             } else if ("true" == v.toLowerCase()) {
-                jsonValue = true
+                token = Value(true)
             } else if ("false" == v.toLowerCase()) {
-                jsonValue = false
+                token = Value(false)
             } else if (v == "null") {
-                jsonValue = null
+                token = Value(null)
             } else {
                 throw KlaxonException("Unexpected character at position ${index-1}"
-                    + ": '$c' (ASCII: ${c.toInt()})'")
+                        + ": '$c' (ASCII: ${c.toInt()})'")
             }
 
-            tokenType = TokenType.VALUE
         } else {
-            tokenType = TokenType.EOF
+            token = EOF
         }
 
-        return Token(tokenType, jsonValue)
+        return token
     }
 
-    private fun log(s: String) = if (Debug.verbose) println(s) else ""
+
+    private fun log(s: String) { if (Debug.verbose) println(s) }
 }

--- a/klaxon/src/main/kotlin/com/beust/klaxon/Lexer.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/Lexer.kt
@@ -7,7 +7,7 @@ import java.util.regex.Pattern
 /**
  * if `lenient` is true, names (the identifiers left of the colon) are allowed to not be surrounded by double quotes.
  */
-class Lexer(passedReader: Reader, val lenient: Boolean = false): Iterator<Token<*>> {
+class Lexer(passedReader: Reader, val lenient: Boolean = false): Iterator<Token> {
     var index = 0
     var line = 1
 
@@ -55,9 +55,9 @@ class Lexer(passedReader: Reader, val lenient: Boolean = false): Iterator<Token<
                 || c in NULL_LETTERS
     }
 
-    private var peeked: Token<*>? = null
+    private var peeked: Token? = null
 
-    fun peek() : Token<*> {
+    fun peek() : Token {
         peeked = peeked ?: actualNextToken()
         return peeked!!
     }
@@ -65,19 +65,19 @@ class Lexer(passedReader: Reader, val lenient: Boolean = false): Iterator<Token<
     override fun next() = nextToken()
     override fun hasNext() = peek() !is EOF
 
-    fun nextToken(): Token<*> {
+    fun nextToken(): Token {
         return peeked?.also { peeked = null } ?: actualNextToken()
     }
 
     private var expectName = false
 
-    private fun actualNextToken() : Token<*> {
+    private fun actualNextToken() : Token {
 
         if (isDone) {
             return EOF
         }
 
-        val token: Token<*>
+        val token: Token
         var c = nextChar()
         val currentValue = StringBuilder()
 

--- a/klaxon/src/main/kotlin/com/beust/klaxon/StateMachine.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/StateMachine.kt
@@ -6,13 +6,13 @@ import com.beust.klaxon.token.TokenType
 private data class TokenStatus(val status: Status, val tokenType: TokenType)
 
 class StateMachine(private val streaming: Boolean) {
-    private val map = hashMapOf<TokenStatus, (world: World, token: Token<*>) -> World>()
+    private val map = hashMapOf<TokenStatus, (world: World, token: Token) -> World>()
 
-    fun put(status: Status, tokenType: TokenType, processor: (world: World, token: Token<*>) -> World) {
+    fun put(status: Status, tokenType: TokenType, processor: (world: World, token: Token) -> World) {
         map[TokenStatus(status, tokenType)] = processor
     }
 
-    fun next(world: World, token: Token<*>) : World {
+    fun next(world: World, token: Token) : World {
         val pair = TokenStatus(world.status, token.tokenType)
         val processor = map[pair]
 
@@ -30,7 +30,7 @@ class StateMachine(private val streaming: Boolean) {
                     return result.toString()
                 }
 
-                val validTokens = map.keys.filter { it.status == world.status }.map { it.tokenType.value.toString() }
+                val validTokens = map.keys.filter { it.status == world.status }.map { it.tokenType.toString() }
                 val validTokenMessage =
                         if (validTokens.size == 1) validTokens[0]
                         else formatList(validTokens)

--- a/klaxon/src/main/kotlin/com/beust/klaxon/StateMachine.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/StateMachine.kt
@@ -1,15 +1,18 @@
 package com.beust.klaxon
 
+import com.beust.klaxon.token.Token
+import com.beust.klaxon.token.TokenType
+
 private data class TokenStatus(val status: Status, val tokenType: TokenType)
 
 class StateMachine(private val streaming: Boolean) {
-    private val map = hashMapOf<TokenStatus, (world: World, token: Token) -> World>()
+    private val map = hashMapOf<TokenStatus, (world: World, token: Token<*>) -> World>()
 
-    fun put(status: Status, tokenType: TokenType, processor: (world: World, token: Token) -> World) {
+    fun put(status: Status, tokenType: TokenType, processor: (world: World, token: Token<*>) -> World) {
         map[TokenStatus(status, tokenType)] = processor
     }
 
-    fun next(world: World, token: Token) : World {
+    fun next(world: World, token: Token<*>) : World {
         val pair = TokenStatus(world.status, token.tokenType)
         val processor = map[pair]
 
@@ -27,12 +30,12 @@ class StateMachine(private val streaming: Boolean) {
                     return result.toString()
                 }
 
-                val validTokens = map.keys.filter { it.status == world.status }.map { it.tokenType.value }
+                val validTokens = map.keys.filter { it.status == world.status }.map { it.tokenType.value.toString() }
                 val validTokenMessage =
                         if (validTokens.size == 1) validTokens[0]
                         else formatList(validTokens)
 
-                val message = "Expected $validTokenMessage, not '${token.tokenType.value}' at line ${world
+                val message = "Expected $validTokenMessage, not '$token' at line ${world
                         .line}" +
                     "\n   (internal error: \"No processor found for: (${world.status}, $token)\""
                 throw KlaxonException(message)

--- a/klaxon/src/main/kotlin/com/beust/klaxon/token/Token.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/token/Token.kt
@@ -8,33 +8,38 @@ package com.beust.klaxon.token
  * The rest of the Token objects are singletons (Kotlin 'object'),
  * which allows them to be used as types (like enums).
  */
-sealed class Token<out T>(val value: T) {
-    override fun equals(other: Any?): Boolean {
-        return super.equals(other)
-        || (other is Token<*> && value == other.value)
-    }
+sealed class Token {
+    override fun equals(other: Any?): Boolean =
+        super.equals(other)
+                || (this is Value<*> && other is Value<*> && this.value == other.value)
 
-    override fun hashCode(): Int {
-        return value?.hashCode() ?: 0
-    }
+    override fun hashCode(): Int = javaClass.hashCode()
 
-    override fun toString(): String {
-        return "${this::class.java.simpleName} (${tokenType.value})"
+    override fun toString(): String = when(this) {
+        is Value<*> -> if (value is String) "\"$value\"" else value.toString()
+        is VALUE_TYPE -> "a value"
+        is LEFT_BRACE -> "{"
+        is RIGHT_BRACE -> "}"
+        is LEFT_BRACKET -> "["
+        is RIGHT_BRACKET -> "]"
+        is COMMA -> ","
+        is COLON -> ":"
+        is EOF -> "EOF"
     }
 
     val tokenType: TokenType
-        get() = if (this is Value) VALUE_TYPE else this
+        get() = if (this is Value<*>) VALUE_TYPE else this
 }
 
-class Value<out T>(value: T) : Token<T>(value)
-object VALUE_TYPE : Token<String>("a value")    // Use as a TokenType only
-object LEFT_BRACE : Token<String>("\"{\"")
-object RIGHT_BRACE : Token<String>("\"}\"")
-object LEFT_BRACKET : Token<String>("\"[\"")
-object RIGHT_BRACKET : Token<String>("\"]\"")
-object COMMA : Token<String>("\",\"")
-object COLON : Token<String>("\":\"")
-object EOF : Token<String>("EOF")
+open class Value<out T>(val value: T) : Token()
+object VALUE_TYPE : Value<Nothing?>(null)   // Use as a TokenType only
+object LEFT_BRACE : Token()
+object RIGHT_BRACE : Token()
+object LEFT_BRACKET : Token()
+object RIGHT_BRACKET : Token()
+object COMMA : Token()
+object COLON : Token()
+object EOF : Token()
 
 // This should be used when referring to a Token as a type, to avoid confusion. (see StateMachine)
-typealias TokenType = Token<*>
+typealias TokenType = Token

--- a/klaxon/src/main/kotlin/com/beust/klaxon/token/Token.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/token/Token.kt
@@ -1,0 +1,40 @@
+package com.beust.klaxon.token
+
+/**
+ * Token produced by the Lexer. This construct (sealed class) allows Tokens
+ * to be used both as types and as actual Token objects.
+ *
+ * Value Tokens are generic, so their value field doesn't need to be casted from Any?.
+ * The rest of the Token objects are singletons (Kotlin 'object'),
+ * which allows them to be used as types (like enums).
+ */
+sealed class Token<out T>(val value: T) {
+    override fun equals(other: Any?): Boolean {
+        return super.equals(other)
+        || (other is Token<*> && value == other.value)
+    }
+
+    override fun hashCode(): Int {
+        return value?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "${this::class.java.simpleName} (${tokenType.value})"
+    }
+
+    val tokenType: TokenType
+        get() = if (this is Value) VALUE_TYPE else this
+}
+
+class Value<out T>(value: T) : Token<T>(value)
+object VALUE_TYPE : Token<String>("a value")    // Use as a TokenType only
+object LEFT_BRACE : Token<String>("\"{\"")
+object RIGHT_BRACE : Token<String>("\"}\"")
+object LEFT_BRACKET : Token<String>("\"[\"")
+object RIGHT_BRACKET : Token<String>("\"]\"")
+object COMMA : Token<String>("\",\"")
+object COLON : Token<String>("\":\"")
+object EOF : Token<String>("EOF")
+
+// This should be used when referring to a Token as a type, to avoid confusion. (see StateMachine)
+typealias TokenType = Token<*>

--- a/klaxon/src/test/kotlin/com/beust/klaxon/LexerTest.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/LexerTest.kt
@@ -1,5 +1,6 @@
 package com.beust.klaxon
 
+import com.beust.klaxon.token.*
 import org.testng.Assert
 import org.testng.annotations.Test
 import java.io.StringReader
@@ -8,13 +9,14 @@ import java.io.StringReader
 class LexerTest {
 
     val expected = listOf(
-            Token(TokenType.LEFT_BRACE),
+            LEFT_BRACE,
             *value("a", 1),
-            Token(TokenType.COMMA),
+            COMMA,
             *value("ab", 1),
-            Token(TokenType.COMMA),
+            COMMA,
             *value("ab", 12),
-            Token(TokenType.RIGHT_BRACE))
+            RIGHT_BRACE
+    )
 
     fun basic() {
         val s = """{
@@ -40,6 +42,6 @@ class LexerTest {
         Assert.assertEquals(result, expected)
     }
 
-    private fun value(name: String, value: Any): Array<Token>
-        = arrayOf(Token(TokenType.VALUE, name), Token(TokenType.COLON), Token(TokenType.VALUE, value))
+    private fun value(name: String, value: Any): Array<Token<*>>
+        = arrayOf(Value(name), COLON, Value(value))
 }

--- a/klaxon/src/test/kotlin/com/beust/klaxon/LexerTest.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/LexerTest.kt
@@ -42,6 +42,6 @@ class LexerTest {
         Assert.assertEquals(result, expected)
     }
 
-    private fun value(name: String, value: Any): Array<Token<*>>
+    private fun value(name: String, value: Any): Array<Token>
         = arrayOf(Value(name), COLON, Value(value))
 }


### PR DESCRIPTION
Overview:
Taking advantage of a very handy Kotlin feature, sealed classes, Tokens can now be used both as a type and as data. This makes the TokenType enum class redundant.
Every kind of Token is now its own object/class, making it much easier to distinguish between tokens (instead of trying to cast from Any? everywhere), simplifying parsing methods and the production of Tokens.

Main changes:
Token.kt: New file containing the Token sealed class and its inherited objects, as well as a tokenType property which simply returns 'this' as a TokenType alias (in case of Value, returns a singleton version of Value).
Lexer.kt: Remove all uses of TokenType and just create the appropriate Token in actualNextToken(). Kotlinify some methods.
JsonReader.kt: Make consumeToken() generic (inline reified), instead of taking a type as an argument. Add a convenience consumeValue overload which is generic (also inline reified), improving readability of nextInt(), nextBoolean() etc.

All tests pass.