### PR TITLE
strings should be escaped in keys too

### DIFF
--- a/klaxon/src/main/kotlin/com/beust/klaxon/JsonObject.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/JsonObject.kt
@@ -31,7 +31,7 @@ by map {
                 indent(result, level + 1)
             }
 
-            result.append("\"").append(k).append("\":")
+            result.append(Render.renderString(k)).append(":")
             if (prettyPrint && !canonical) {
                 result.append(" ")
             }

--- a/testing/test-resources/src/main/resources/escaped.json
+++ b/testing/test-resources/src/main/resources/escaped.json
@@ -1,3 +1,3 @@
 {
-  "s": "text field \"s\"\nnext line\fform feed\ttab\\rev solidus\/solidus\bbackspace"
+  "text field \"s\"\nnext line\fform feed\ttab\\rev solidus\/solidus\bbackspace\u2018": "text field \"s\"\nnext line\fform feed\ttab\\rev solidus\/solidus\bbackspace\u2018"
 }

--- a/testing/tests/src/test/kotlin/com/beust/klaxon/KlaxonTest.kt
+++ b/testing/tests/src/test/kotlin/com/beust/klaxon/KlaxonTest.kt
@@ -158,8 +158,9 @@ abstract class KlaxonBaseTest {
     }
 
     fun parseStringEscapes() {
+        val s = "text field \"s\"\nnext line\u000cform feed\ttab\\rev solidus/solidus\bbackspace\u2018"
         assertEquals(json {
-            obj("s" to "text field \"s\"\nnext line\u000cform feed\ttab\\rev solidus/solidus\bbackspace")
+            obj(s to s)
         }, read("/escaped.json"))
     }
 
@@ -333,9 +334,9 @@ abstract class KlaxonBaseTest {
 
     fun renderMap() {
         val map = mapOf(
-            "a" to 1,
-            "b" to "x",
-            "c" to null
+                "a" to 1,
+                "b" to "x",
+                "c" to null
         )
 
         assertEquals(valueToString(map), "{\"a\":1,\"b\":\"x\",\"c\":null}")

--- a/testing/tests/src/test/kotlin/com/beust/klaxon/TestTypes.kt
+++ b/testing/tests/src/test/kotlin/com/beust/klaxon/TestTypes.kt
@@ -102,6 +102,6 @@ abstract class BaseTestTypes {
 
     fun testEscapeRender(){
         val j = read("/escaped.json") as JsonObject
-        assertEquals("""{"s":"text field \"s\"\nnext line\fform feed\ttab\\rev solidus/solidus\bbackspace"}""", j.toJsonString())
+        assertEquals("""{"text field \"s\"\nnext line\fform feed\ttab\\rev solidus/solidus\bbackspace\u2018":"text field \"s\"\nnext line\fform feed\ttab\\rev solidus/solidus\bbackspace\u2018"}""", j.toJsonString())
     }
 }


### PR DESCRIPTION
```
$ python
>>> print(json.dumps({'"':1}))
{"\"": 1}
```

In Klaxon we get `{""": 1}` instead of `{"\"": 1}`, which is obviously wrong.

Changed `escape.json` and the escaping tests and fixed the code.