### PR TITLE
Enable plain object serialisation in DSL

### DIFF
--- a/klaxon/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
@@ -2,6 +2,7 @@ package com.beust.klaxon
 
 import java.lang.reflect.ParameterizedType
 import java.math.BigDecimal
+import java.math.BigInteger
 import kotlin.reflect.jvm.jvmErasure
 
 /**
@@ -61,6 +62,7 @@ class DefaultConverter(private val klaxon: Klaxon, private val allPaths: HashMap
                 }
                 joinToString(valueList, "{", "}")
             }
+            is BigInteger -> value.toString()
             else -> {
                 val valueList = arrayListOf<String>()
                 val properties = Annotations.findNonIgnoredProperties(value::class, klaxon.propertyStrategies)

--- a/klaxon/src/main/kotlin/com/beust/klaxon/KlaxonJson.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/KlaxonJson.kt
@@ -1,7 +1,5 @@
 package com.beust.klaxon
 
-import java.math.BigInteger
-
 /**
  * The class used to define the DSL that generates JSON documents. All the functions defined in this class
  * can be used inside a `json { ... }` call.

--- a/klaxon/src/main/kotlin/com/beust/klaxon/KlaxonJson.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/KlaxonJson.kt
@@ -25,20 +25,11 @@ interface KlaxonJson {
         internal val theKlaxonJson = object : KlaxonJson { }
 
         private fun convert(value: Any?): Any? = when (value) {
-            is Int -> value
-            is Long -> value
-            is String -> value
-            is Boolean -> value
             is Float -> value.toDouble()
-            is Double -> value
-            is BigInteger -> value
-            is JsonObject -> value
-            is JsonArray<*> -> value
             is Short -> value.toInt()
             is Byte -> value.toInt()
             null -> null
-            else ->
-                throw IllegalArgumentException("Unrecognized type `${value::class}` with value `$value`")
+            else -> value
         }
     }
 

--- a/klaxon/src/main/kotlin/com/beust/klaxon/Render.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/Render.kt
@@ -29,10 +29,9 @@ object Render {
                     properties.forEach { prop ->
                         prop.getter.call(v)?.let { getValue ->
                             val jsonField = if (v != null) Annotations.findJsonAnnotation(v::class, prop.name)
-                            else null
-                            val fieldName =
-                                if (jsonField != null && jsonField.nameInitialized()) jsonField.name
-                                else prop.name
+                                            else null
+                            val fieldName = if (jsonField != null && jsonField.nameInitialized()) jsonField.name
+                                            else prop.name
 
                             if (comma) {
                                 result.append(",")
@@ -44,6 +43,7 @@ object Render {
                             if (prettyPrint && !canonical) {
                                 result.append(" ")
                             }
+
                             renderValue(getValue, result, prettyPrint, canonical, level)
                         }
                     }

--- a/klaxon/src/main/kotlin/com/beust/klaxon/Render.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/Render.kt
@@ -3,54 +3,24 @@ package com.beust.klaxon
 import java.text.DecimalFormat
 
 object Render {
-    fun renderValue(v: Any?, result: Appendable, prettyPrint: Boolean, canonical: Boolean, level: Int) {
+    tailrec fun renderValue(v: Any?, result: Appendable, prettyPrint: Boolean, canonical: Boolean, level: Int) {
         when (v) {
             is JsonBase -> v.appendJsonStringImpl(result, prettyPrint, canonical, level)
             is String -> result.renderString(v)
             is Map<*, *> -> renderValue(
-                JsonObject(v.mapKeys { it.key.toString() }.mapValues { it.value }),
-                result,
-                prettyPrint,
-                canonical,
-                level)
+                    JsonObject(v.mapKeys { it.key.toString() }.mapValues { it.value }),
+                    result,
+                    prettyPrint,
+                    canonical,
+                    level)
             is List<*> -> renderValue(JsonArray(v), result, prettyPrint, canonical, level)
             is Pair<*, *> -> renderValue(v.second, result.renderString(v.first.toString()).append(": "), prettyPrint, canonical, level)
             is Double, is Float ->
                 result.append(if (canonical) decimalFormat.format(v) else v.toString())
-            is Int, is Boolean -> result.append(v.toString())
+            null -> result.append("null")
             else -> {
-                val properties = if (v != null) Annotations.findNonIgnoredProperties(v::class, Klaxon().propertyStrategies)
-                else emptyList()
-
-                if (properties.isNotEmpty()) {
-                    result.append('{')
-                    var comma = false
-
-                    properties.forEach { prop ->
-                        prop.getter.call(v)?.let { getValue ->
-                            val jsonField = if (v != null) Annotations.findJsonAnnotation(v::class, prop.name)
-                                            else null
-                            val fieldName = if (jsonField != null && jsonField.nameInitialized()) jsonField.name
-                                            else prop.name
-
-                            if (comma) {
-                                result.append(",")
-                            } else {
-                                comma = true
-                            }
-
-                            result.renderString(fieldName).append(':')
-                            if (prettyPrint && !canonical) {
-                                result.append(" ")
-                            }
-
-                            renderValue(getValue, result, prettyPrint, canonical, level)
-                        }
-                    }
-                    result.append('}')
-                } else {
-                    result.append(v.toString())
-                }
+                // TODO - Here we are reusing Converter.toJson() logic, but loose support for prettyPrint and canonical
+                result.append(Klaxon().findConverter(v).toJson(v))
             }
         }
     }
@@ -92,9 +62,9 @@ object Render {
     }
 
     private fun isNotPrintableUnicode(c: Char): Boolean =
-        c in '\u0000'..'\u001F' ||
-                c in '\u007F'..'\u009F' ||
-                c in '\u2000'..'\u20FF'
+            c in '\u0000'..'\u001F' ||
+                    c in '\u007F'..'\u009F' ||
+                    c in '\u2000'..'\u20FF'
 
     private val decimalFormat = DecimalFormat("0.0####E0;-0.0####E0")
 }

--- a/klaxon/src/test/kotlin/com/beust/klaxon/Issue167Test.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/Issue167Test.kt
@@ -18,12 +18,13 @@ class Issue167Test {
         println("Json array: ${anArray.toJsonString()}")
 
         val aPlainObject = TestObject(10, "test string", 3.141659f)
+        println("Plain object: ${aPlainObject.toString()}")
 
         val aMix = json {
             obj (
                 "theArray" to anArray,
                 "theObject" to aJsonObject,
-                "thePlainObject" to aPlainObject,
+                "thePlainObject" to aPlainObject,   // This entry would fail previously: IllegalArgumentException
                 "anInt" to 4
             )
         }

--- a/klaxon/src/test/kotlin/com/beust/klaxon/Issue167Test.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/Issue167Test.kt
@@ -1,0 +1,33 @@
+package com.beust.klaxon
+
+import org.testng.annotations.Test
+
+data class TestObject(val a: Int, val b: String, val c: Float)
+
+@Test
+class Issue167Test {
+    fun issue167() {
+        val aJsonObject = json {
+            obj("a" to 1, "b" to "value")
+        }
+        println("Json object: ${aJsonObject.toJsonString()}")
+
+        val anArray = json {
+            array("a", 1, false)
+        }
+        println("Json array: ${anArray.toJsonString()}")
+
+        val aPlainObject = TestObject(10, "test string", 3.141659f)
+
+        val aMix = json {
+            obj (
+                "theArray" to anArray,
+                "theObject" to aJsonObject,
+                "thePlainObject" to aPlainObject,
+                "anInt" to 4
+            )
+        }
+
+        println("Mix: ${aMix.toJsonString()}")
+    }
+}

--- a/klaxon/src/test/kotlin/com/beust/klaxon/Issue167Test.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/Issue167Test.kt
@@ -2,7 +2,11 @@ package com.beust.klaxon
 
 import org.testng.annotations.Test
 
-data class TestObject(val a: Int, val b: String, val c: Float)
+data class TestObject(
+    val a: Int,
+    @Json(name = "filed_b")
+    val b: String,
+    val c: Float)
 
 @Test
 class Issue167Test {
@@ -24,11 +28,12 @@ class Issue167Test {
             obj (
                 "theArray" to anArray,
                 "theObject" to aJsonObject,
-                "thePlainObject" to aPlainObject,   // This entry would fail previously: IllegalArgumentException
+                "thePlainObject" to aPlainObject,   // This entry would previously fail with IllegalArgumentException
                 "anInt" to 4
             )
         }
 
-        println("Mix: ${aMix.toJsonString()}")
+        // Just checking that we don't get an exception when serializing
+        println("Mix: ${aMix.toJsonString(prettyPrint = true, canonical = false)}")
     }
 }

--- a/klaxon/src/test/kotlin/com/beust/klaxon/Main.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/Main.kt
@@ -1,5 +1,6 @@
 package com.beust.klaxon.test
 
+import java.util.ArrayList
 import com.beust.klaxon.*
 
 fun main(args : Array<String>) {
@@ -26,13 +27,11 @@ fun main(args : Array<String>) {
     }
     println("Json array: ${anArray.toJsonString()}")
 
-    val aPlainObject = Triple("hi", 3, true)
     val aMix = json {
-        obj(
-            "theArray" to anArray,
-            "theObject" to anObject,
-            "thePlainObject" to aPlainObject,
-            "anInt" to 4
+        obj (
+                "theArray" to anArray,
+                "theObject" to anObject,
+                "anInt" to 4
         )
     }
     println("Mix: ${aMix.toJsonString()}")
@@ -97,9 +96,9 @@ fun example1() {
     println("=== All grades bigger than 75")
     val result = array.filterIsInstance<JsonObject>().map {
         it.obj("schoolResults")
-            ?.array<JsonObject>("scores")?.filter {
-                it.long("grade")!! > 75
-            }!!
+                ?.array<JsonObject>("scores")?.filter {
+                    it.long("grade")!! > 75
+                }!!
     }
     println("Result: ${result}")
 }

--- a/klaxon/src/test/kotlin/com/beust/klaxon/Main.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/Main.kt
@@ -1,6 +1,5 @@
 package com.beust.klaxon.test
 
-import java.util.ArrayList
 import com.beust.klaxon.*
 
 fun main(args : Array<String>) {
@@ -27,11 +26,13 @@ fun main(args : Array<String>) {
     }
     println("Json array: ${anArray.toJsonString()}")
 
+    val aPlainObject = Triple("hi", 3, true)
     val aMix = json {
-        obj (
-                "theArray" to anArray,
-                "theObject" to anObject,
-                "anInt" to 4
+        obj(
+            "theArray" to anArray,
+            "theObject" to anObject,
+            "thePlainObject" to aPlainObject,
+            "anInt" to 4
         )
     }
     println("Mix: ${aMix.toJsonString()}")
@@ -96,9 +97,9 @@ fun example1() {
     println("=== All grades bigger than 75")
     val result = array.filterIsInstance<JsonObject>().map {
         it.obj("schoolResults")
-                ?.array<JsonObject>("scores")?.filter {
-                    it.long("grade")!! > 75
-                }!!
+            ?.array<JsonObject>("scores")?.filter {
+                it.long("grade")!! > 75
+            }!!
     }
     println("Result: ${result}")
 }

--- a/klaxon/src/test/kotlin/com/beust/klaxon/TypeAdapterTest.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/TypeAdapterTest.kt
@@ -49,15 +49,16 @@ class TypeAdapterTest {
         val shapes = Klaxon().parseArray<BogusData>(json)
     }
 
+    class BogusShapeTypeAdapter: TypeAdapter<Shape> {
+        override fun classFor(type: Any): KClass<out Shape> = when(type as Int) {
+            1 -> Rectangle::class
+            else -> throw IllegalArgumentException("Unknown type: $type")
+        }
+    }
     @Test(expectedExceptions = [IllegalArgumentException::class],
             expectedExceptionsMessageRegExp = ".*Unknown type.*")
     fun unknownDiscriminantValue() {
-        class BogusShapeTypeAdapter: TypeAdapter<Shape> {
-            override fun classFor(type: Any): KClass<out Shape> = when(type as Int) {
-                1 -> Rectangle::class
-                else -> throw IllegalArgumentException("Unknown type: $type")
-            }
-        }
+
 
         class BogusData (
                 @TypeFor(field = "shape", adapter = BogusShapeTypeAdapter::class)


### PR DESCRIPTION
Hi Cedric,

Sorry, I ended up deleting my branch and rebasing on the latest upstream code, which doesn't let me reopen the PR  (#223).
Besides the changes discussed before I've updated `DefaultConverter` to support `BigInteger` (the test was failing after my update) and I had to make a small change to TypeAdapterTest.kt because it was complaining about the class passed to `@TypeFor`.

There is still a test that fails for me since it can't find "data.json" file (?).

Regards,
Alfonso