### PR TITLE
Encode attributes with null values #253

### DIFF
--- a/klaxon/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
@@ -68,11 +68,10 @@ class DefaultConverter(private val klaxon: Klaxon, private val allPaths: HashMap
                 val valueList = arrayListOf<String>()
                 val properties = Annotations.findNonIgnoredProperties(value::class, klaxon.propertyStrategies)
                 properties.forEach { prop ->
-                    prop.getter.call(value)?.let { getValue ->
-                        val jsonValue = klaxon.toJsonString(getValue, prop)
-                        val fieldName = Annotations.retrieveJsonFieldName(klaxon, value::class, prop)
-                        valueList.add("\"$fieldName\" : $jsonValue")
-                    }
+                    val getValue = prop.getter.call(value)
+                    val jsonValue = klaxon.toJsonString(getValue, prop)
+                    val fieldName = Annotations.retrieveJsonFieldName(klaxon, value::class, prop)
+                    valueList.add("\"$fieldName\" : $jsonValue")
                 }
                 joinToString(valueList, "{", "}")
             }

--- a/klaxon/src/test/kotlin/com/beust/klaxon/Issue253Test.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/Issue253Test.kt
@@ -1,0 +1,22 @@
+package com.beust.klaxon
+
+import org.testng.annotations.Test
+import kotlin.test.assertEquals
+
+@Test
+class Issue253Test {
+
+    data class ObjWithNullAttr(
+            val myAttr: Int?
+    )
+
+    fun issue253() {
+        val obj = ObjWithNullAttr(null)
+        val jsonStr = Klaxon().toJsonString(obj)
+        assertEquals(
+                """{"myAttr":null}""",
+                jsonStr.replace(" ", "")
+        )
+        Klaxon().parse<ObjWithNullAttr>(jsonStr)
+    }
+}


### PR DESCRIPTION
Prevent DefaultConverter from skipping attributes with null values when encoding.

Also includes a test to make sure the issue is and stays solved.