### PR TITLE
Call use on FileReaders Klaxon creates

### DIFF
--- a/klaxon/src/main/kotlin/com/beust/klaxon/Klaxon.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/Klaxon.kt
@@ -53,15 +53,17 @@ class Klaxon : ConverterFinder {
      * Parse a JSON file into an object.
      */
     @Suppress("unused")
-    inline fun <reified T> parse(file: File): T?
-            = maybeParse(parser(T::class).parse(FileReader(file)) as JsonObject)
+    inline fun <reified T> parse(file: File): T? = FileReader(file).use { reader ->
+        maybeParse(parser(T::class).parse(reader) as JsonObject)
+    }
 
     /**
      * Parse a JSON file into a List.
      */
     @Suppress("unused")
-    inline fun <reified T> parseArray(file: File): List<T>?
-            = parseFromJsonArray(parser(T::class).parse(FileReader(file)) as JsonArray<*>)
+    inline fun <reified T> parseArray(file: File): List<T>? = FileReader(file).use { reader ->
+        parseFromJsonArray(parser(T::class).parse(reader) as JsonArray<*>)
+    }
 
     /**
      * Parse an InputStream into an object.


### PR DESCRIPTION
### Description of the Change

This PR calls `use` on all `FileReader` Klaxon creates from files given to it by the user.

### Motivation

Klaxon should close a `FileReader` if it opens one to prevent issues when a user tries to delete a file they previously gave to Klaxon.

### Possible Drawbacks

None.

### Verification Process

I'm not sure how I could go about testing this, but this is a simple change and I have been using this fix in my own code.

### Applicable Issues

Closes #259.
