### PR TITLE
Parse into object instance if constructor parsing fails

### DIFF
--- a/klaxon/src/main/kotlin/com/beust/klaxon/JsonObjectConverter.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/JsonObjectConverter.kt
@@ -88,7 +88,7 @@ class JsonObjectConverter(private val klaxon: Klaxon, private val allPaths: Hash
                         parameterMap.entries.map { it.key.name.toString() + ": " + it.value.toString() })
                 null
             }
-        }
+        } ?: concreteClass.objectInstance
 
         if (errorMessage.any()) {
             throw KlaxonException(errorMessage.joinToString("\n"))

--- a/klaxon/src/test/kotlin/com/beust/klaxon/ParseObjectTest.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/ParseObjectTest.kt
@@ -1,0 +1,14 @@
+package com.beust.klaxon
+
+import org.testng.annotations.Test
+import kotlin.test.assertEquals
+
+@Test
+class ParseObjectTest {
+
+    object Foo
+
+    fun `test parsing an object`() {
+        assertEquals(Foo, Klaxon().parse<Foo>("{}"))
+    }
+}


### PR DESCRIPTION
In the event that a user wants to parse into an object, no constructor will be found, so `result` will be `null` inside `initIntoUserClass`. This PR tries to parse `concreteClass` into an object instance if parsing into a normal class instance fails.