### PR TITLE
Add correction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ a class that will translate these integer values into the correct class:
 
 ```kotlin
 class ShapeTypeAdapter: TypeAdapter<Shape> {
-    override fun instantiate(type: Any): KClass<out Shape> = when(type as Int) {
+    override fun classFor(type: Any): KClass<out Shape> = when(type as Int) {
         1 -> Rectangle::class
         2 -> Circle::class
         else -> throw IllegalArgumentException("Unknown type: $type")


### PR DESCRIPTION
* Changes 'instantiate' to 'classFor' in example code for polymorphic
fields

This example code looks to be incorrect and doesn't compile. I believe this is supposed to be similar to the previous example on polymorphic classes, whereas the overridden function is `classFor` instead of `instantiate` 😊

```
class ShapeTypeAdapter: TypeAdapter<Shape> {
    override fun instantiate(type: Any): KClass<out Shape> = when(type as Int) {
        1 -> Rectangle::class
        2 -> Circle::class
        else -> throw IllegalArgumentException("Unknown type: $type")
    }
}
```