### PR TITLE
Do not try to set final fields

### DIFF
--- a/klaxon/src/main/kotlin/com/beust/klaxon/JsonObjectConverter.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/JsonObjectConverter.kt
@@ -1,6 +1,7 @@
 package com.beust.klaxon
 
 import com.beust.klaxon.internal.firstNotNullResult
+import java.lang.reflect.Modifier
 import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KMutableProperty
@@ -128,9 +129,9 @@ class JsonObjectConverter(private val klaxon: Klaxon, private val allPaths: Hash
                     it.javaSetter!!.invoke(result, value)
                 }
             } else {
-                // Mutable property
+                // Non-Mutable property
                 val field = it.javaField
-                if (field != null && result != null) {
+                if ( field != null && result != null && !Modifier.isFinal(field.modifiers) ) {
                     val value = map[it.name]
                     field.isAccessible = true
                     field.set(result, value)

--- a/klaxon/src/test/kotlin/com/beust/klaxon/TwoConstructorsWithFinalField.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/TwoConstructorsWithFinalField.kt
@@ -1,0 +1,33 @@
+package com.beust.klaxon
+
+import org.testng.Assert
+import org.testng.annotations.Test
+
+@Test
+class TwoConstructorsWithFinalField {
+
+    class StringOrInt (
+        val stringOrInt: String
+    ) {
+        constructor( stringOrInt: Int ) : this( "$stringOrInt" )
+    }
+
+    fun stringWorks() {
+
+        val sampleJson = """{"stringOrInt":"5"}"""
+        val result = Klaxon().parse<StringOrInt>(sampleJson)
+
+        Assert.assertNotNull(result)
+        Assert.assertEquals(result!!.stringOrInt, "5")
+    }
+
+    fun intWorks() {
+
+        val sampleJson = """{"stringOrInt":5}"""
+        val result = Klaxon().parse<StringOrInt>(sampleJson)
+
+        Assert.assertNotNull(result)
+        Assert.assertEquals(result!!.stringOrInt, "5")
+    }
+
+}


### PR DESCRIPTION
**Problem:**
Assume a class, that has two constructors (see test `TwoConstructorsWithFinalField`):
* one primary constructor with value-parameters. (resulting in Java final fields)
* a secondary constructor.

When instantiated using Klaxon from JSON, the final fields of the primary constructor can not be filled , which may result in a non-neccessary Exception.
```java.lang.IllegalArgumentException: Can not set final {{typeX}} field {{...}} to {{typeX or typeY}}```

**Solution:**
Ignore final fields after instantiating the class in Klaxon object converter.

**Reasoning:**
Final fields can not be set to a new value.
All final fields can be ignored by Klaxon after instantiation, because (in JVM) they must have already been initialized during construction of the object.
