### PR TITLE
Allow Property to be Absent in JSON when Value is Null

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,34 @@ println(Klaxon().toJsonString(Data("id", "foo")))
 
 Properties that are not assigned an index will be displayed in a non deterministic order in the output JSON.
 
+#### `serializeNull`
+
+By default, all properties with the value null are serialized to JSON, for example: 
+
+```kotlin
+class Data(
+    val id: Int?
+)
+println(Klaxon().toJsonString(Data(null)))
+
+// displays { "id": null }
+```
+
+If you instead want the properties with a null value to be absent in the JSON string, 
+use `@Json(serializeNull = false)`:
+
+```kotlin
+class Data(
+    @Json(serializeNull = false)
+    val id: Int?
+)
+println(Klaxon().toJsonString(Data(null)))
+
+// displays {}
+```
+
+If `serializeNull` is false, the Kotlin default values for this property will be ignored during parsing. 
+Instead, if the property is absent in the JSON, the value will default to `null`.
 
 ### Renaming fields
 

--- a/klaxon/src/main/java/com/beust/klaxon/Json.kt
+++ b/klaxon/src/main/java/com/beust/klaxon/Json.kt
@@ -27,7 +27,13 @@ annotation class Json(
     /**
      * Where this property should appear in the JSON output. Lower numbers appear first.
      */
-    val index: Long = Long.MAX_VALUE
+    val index: Long = Long.MAX_VALUE,
+
+    /**
+     * If false, property will be absent in JSON when value is null.
+     * If true, property will be present in JSON with value null.
+     */
+    val serializeNull: Boolean = true
 )
 
 fun Json.nameInitialized() = this.name != NAME_NOT_INITIALIZED

--- a/klaxon/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
@@ -78,9 +78,11 @@ class DefaultConverter(private val klaxon: Klaxon, private val allPaths: HashMap
                 val properties = Annotations.findNonIgnoredProperties(value::class, klaxon.propertyStrategies)
                 properties.forEach { prop ->
                     val getValue = prop.getter.call(value)
-                    val jsonValue = klaxon.toJsonString(getValue, prop)
-                    val fieldName = Annotations.retrieveJsonFieldName(klaxon, value::class, prop)
-                    valueList.add("\"$fieldName\" : $jsonValue")
+                    if (Annotations.findJsonAnnotation(value::class, prop.name)?.serializeNull != false || getValue != null) {
+                            val jsonValue = klaxon.toJsonString(getValue, prop)
+                            val fieldName = Annotations.retrieveJsonFieldName(klaxon, value::class, prop)
+                            valueList.add("\"$fieldName\" : $jsonValue")
+                        }
                 }
                 joinToString(valueList, "{", "}")
             }

--- a/klaxon/src/main/kotlin/com/beust/klaxon/JsonObjectConverter.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/JsonObjectConverter.kt
@@ -207,7 +207,7 @@ class JsonObjectConverter(private val klaxon: Klaxon, private val allPaths: Hash
                             .fromJson(JsonValue(jValue, prop.returnType.javaType,
                                     kType, klaxon))
                     result[prop.name] = convertedValue
-                } else if (jsonAnnotation?.serializeNull == false) {
+                } else if (jsonAnnotation?.serializeNull == false && prop.returnType.isMarkedNullable) {
                     // provide a default value of null, overriding Kotlin default
                     result[prop.name] = null
                 } else {

--- a/klaxon/src/main/kotlin/com/beust/klaxon/JsonObjectConverter.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/JsonObjectConverter.kt
@@ -207,6 +207,9 @@ class JsonObjectConverter(private val klaxon: Klaxon, private val allPaths: Hash
                             .fromJson(JsonValue(jValue, prop.returnType.javaType,
                                     kType, klaxon))
                     result[prop.name] = convertedValue
+                } else if (jsonAnnotation?.serializeNull == false) {
+                    // provide a default value of null, overriding Kotlin default
+                    result[prop.name] = null
                 } else {
                     // Didn't find any value for that property: don't do anything. If a value is missing here,
                     // it might still be found as a default value on the constructor, and we'll find out once we

--- a/klaxon/src/test/kotlin/com/beust/klaxon/JsonAnnotationTest.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/JsonAnnotationTest.kt
@@ -50,7 +50,41 @@ class JsonAnnotationTest {
     }
 
     @Test
-    fun serializeNullTest() {
+    fun serializeNullFalseRoundtripWithoutDefault() {
+        // when serializeNull == false, null is the default value during parsing
+        data class ObjWithSerializeNullFalse(
+            @Json(serializeNull = false)
+            val value: Int?
+        )
+
+        val originalObj = ObjWithSerializeNullFalse(null)
+        val serialized = Klaxon().toJsonString(originalObj)
+        Assert.assertEquals("{}", serialized) // with serializeNull = false, the null property is not serialized
+        val parsed = Klaxon().parse<ObjWithSerializeNullFalse>(serialized)
+        val expected = ObjWithSerializeNullFalse(null)
+
+        Assert.assertEquals(expected, parsed)
+    }
+
+    @Test
+    fun serializeNullFalseRoundtripWithDefault() {
+        // Kotlin defaults are ignored when serializeNull == false and replaced with null during parsing
+        data class ObjWithSerializeNullFalseAndDefault(
+            @Json(serializeNull = false)
+            val value: Int? = 1
+        )
+
+        val originalObj = ObjWithSerializeNullFalseAndDefault(null)
+        val serialized = Klaxon().toJsonString(originalObj)
+        Assert.assertEquals("{}", serialized)
+        val parsed = Klaxon().parse<ObjWithSerializeNullFalseAndDefault>(serialized)
+        val expected = ObjWithSerializeNullFalseAndDefault(null)
+
+        Assert.assertEquals(expected, parsed)
+    }
+
+    @Test
+    fun serializeNullFalseValueSet() {
         data class ObjWithSerializeNullFalse(
             @Json(serializeNull = false)
             val value: Int?
@@ -59,19 +93,14 @@ class JsonAnnotationTest {
         Assertions
             .assertThat(
                 Klaxon().toJsonString(
-                    ObjWithSerializeNullFalse(null)
-                )
-            )
-            .isEqualTo("{}") // with serializeNull = false, the field is not serialized
-
-        Assertions
-            .assertThat(
-                Klaxon().toJsonString(
                     ObjWithSerializeNullFalse(1)
                 )
             )
             .isEqualTo("""{"value" : 1}""")
+    }
 
+    @Test
+    fun serializeNullTrue() {
         data class ObjWithSerializeNullTrue(
             @Json(serializeNull = true)
             val value: Int?
@@ -80,7 +109,7 @@ class JsonAnnotationTest {
         Assertions
             .assertThat(
                 Klaxon().toJsonString(
-                ObjWithSerializeNullTrue(null)
+                    ObjWithSerializeNullTrue(null)
                 )
             )
             .isEqualTo("""{"value" : null}""")
@@ -90,63 +119,5 @@ class JsonAnnotationTest {
                 Klaxon().toJsonString(
                     ObjWithSerializeNullTrue(1)))
             .isEqualTo("""{"value" : 1}""")
-    }
-
-    // TODO The following tests show some tricky examples with parsing and defaults
-
-    @Test
-    fun serializeNullFalseParse() {
-        // when serializeNull = false, empty field in JSON should default to null value
-        data class ObjWithSerializeNullFalse(
-            @Json(serializeNull = false)
-            val value: Int?
-        )
-
-        val originalObj = ObjWithSerializeNullFalse(null)
-        val serialized = Klaxon().toJsonString(originalObj)
-        Assert.assertEquals("{}", serialized)
-        val parsed = Klaxon().parse<ObjWithSerializeNullFalse>(serialized)
-        val expected = ObjWithSerializeNullFalse(null)
-
-        Assert.assertEquals(expected, parsed)
-    }
-
-    @Test
-    fun serializeNullFalseParseWithDefault() {
-        // when a default is set, it should override the null default from serializeNull
-        data class ObjWithSerializeNullFalseAndDefault(
-            @Json(serializeNull = false)
-            val value: Int? = 1
-        )
-
-        val originalObj = ObjWithSerializeNullFalseAndDefault(null)
-        val serialized = Klaxon().toJsonString(originalObj)
-        Assert.assertEquals("{}", serialized)
-
-        val parsed = Klaxon().parse<ObjWithSerializeNullFalseAndDefault>(serialized)
-        val expected = ObjWithSerializeNullFalseAndDefault(1)
-
-        Assert.assertEquals(expected, parsed)
-        // The roundtrip object-json-object does not lead to the same object!
-    }
-
-    // Another variant that the previous test could go
-    @Test
-    fun serializeNullFalseParseWithDefaultAlternative() {
-        // Kotlin defaults are ignored when serializeNull == false
-        data class ObjWithSerializeNullFalseAndDefault(
-            @Json(serializeNull = false)
-            val value: Int? = 1
-        )
-
-        val originalObj = ObjWithSerializeNullFalseAndDefault(null)
-        val serialized = Klaxon().toJsonString(originalObj)
-        Assert.assertEquals("{}", serialized)
-
-        val parsed = Klaxon().parse<ObjWithSerializeNullFalseAndDefault>(serialized)
-        val expected = ObjWithSerializeNullFalseAndDefault(null)
-
-        Assert.assertEquals(expected, parsed)
-        // The roundtrip object-json-object leads to the same object
     }
 }

--- a/klaxon/src/test/kotlin/com/beust/klaxon/JsonAnnotationTest.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/JsonAnnotationTest.kt
@@ -120,4 +120,17 @@ class JsonAnnotationTest {
                     ObjWithSerializeNullTrue(1)))
             .isEqualTo("""{"value" : 1}""")
     }
+
+    @Test
+    fun serializeNullWithoutNullableProperty() {
+        data class ObjWithSerializeNullFalse(
+            @Json(serializeNull = false)
+            val value: Int = 1
+        )
+
+        val parsed = Klaxon().parse<ObjWithSerializeNullFalse>("{}")
+        val expected = ObjWithSerializeNullFalse(1)
+
+        Assert.assertEquals(expected, parsed)
+    }
 }

--- a/klaxon/src/test/kotlin/com/beust/klaxon/JsonAnnotationTest.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/JsonAnnotationTest.kt
@@ -91,4 +91,62 @@ class JsonAnnotationTest {
                     ObjWithSerializeNullTrue(1)))
             .isEqualTo("""{"value" : 1}""")
     }
+
+    // TODO The following tests show some tricky examples with parsing and defaults
+
+    @Test
+    fun serializeNullFalseParse() {
+        // when serializeNull = false, empty field in JSON should default to null value
+        data class ObjWithSerializeNullFalse(
+            @Json(serializeNull = false)
+            val value: Int?
+        )
+
+        val originalObj = ObjWithSerializeNullFalse(null)
+        val serialized = Klaxon().toJsonString(originalObj)
+        Assert.assertEquals("{}", serialized)
+        val parsed = Klaxon().parse<ObjWithSerializeNullFalse>(serialized)
+        val expected = ObjWithSerializeNullFalse(null)
+
+        Assert.assertEquals(expected, parsed)
+    }
+
+    @Test
+    fun serializeNullFalseParseWithDefault() {
+        // when a default is set, it should override the null default from serializeNull
+        data class ObjWithSerializeNullFalseAndDefault(
+            @Json(serializeNull = false)
+            val value: Int? = 1
+        )
+
+        val originalObj = ObjWithSerializeNullFalseAndDefault(null)
+        val serialized = Klaxon().toJsonString(originalObj)
+        Assert.assertEquals("{}", serialized)
+
+        val parsed = Klaxon().parse<ObjWithSerializeNullFalseAndDefault>(serialized)
+        val expected = ObjWithSerializeNullFalseAndDefault(1)
+
+        Assert.assertEquals(expected, parsed)
+        // The roundtrip object-json-object does not lead to the same object!
+    }
+
+    // Another variant that the previous test could go
+    @Test
+    fun serializeNullFalseParseWithDefaultAlternative() {
+        // Kotlin defaults are ignored when serializeNull == false
+        data class ObjWithSerializeNullFalseAndDefault(
+            @Json(serializeNull = false)
+            val value: Int? = 1
+        )
+
+        val originalObj = ObjWithSerializeNullFalseAndDefault(null)
+        val serialized = Klaxon().toJsonString(originalObj)
+        Assert.assertEquals("{}", serialized)
+
+        val parsed = Klaxon().parse<ObjWithSerializeNullFalseAndDefault>(serialized)
+        val expected = ObjWithSerializeNullFalseAndDefault(null)
+
+        Assert.assertEquals(expected, parsed)
+        // The roundtrip object-json-object leads to the same object
+    }
 }

--- a/klaxon/src/test/kotlin/com/beust/klaxon/JsonAnnotationTest.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/JsonAnnotationTest.kt
@@ -48,4 +48,47 @@ class JsonAnnotationTest {
         Assertions.assertThat(r).isEqualTo(Config("v1", setOf("abc")))
 
     }
+
+    @Test
+    fun serializeNullTest() {
+        data class ObjWithSerializeNullFalse(
+            @Json(serializeNull = false)
+            val value: Int?
+        )
+
+        Assertions
+            .assertThat(
+                Klaxon().toJsonString(
+                    ObjWithSerializeNullFalse(null)
+                )
+            )
+            .isEqualTo("{}") // with serializeNull = false, the field is not serialized
+
+        Assertions
+            .assertThat(
+                Klaxon().toJsonString(
+                    ObjWithSerializeNullFalse(1)
+                )
+            )
+            .isEqualTo("""{"value" : 1}""")
+
+        data class ObjWithSerializeNullTrue(
+            @Json(serializeNull = true)
+            val value: Int?
+        )
+
+        Assertions
+            .assertThat(
+                Klaxon().toJsonString(
+                ObjWithSerializeNullTrue(null)
+                )
+            )
+            .isEqualTo("""{"value" : null}""")
+
+        Assertions
+            .assertThat(
+                Klaxon().toJsonString(
+                    ObjWithSerializeNullTrue(1)))
+            .isEqualTo("""{"value" : 1}""")
+    }
 }


### PR DESCRIPTION
This allows a property to be made absent in the serialized JSON by setting its value to null. The default remains to make properties with value null present in the JSON as `"name" : null`.

To achieve this, a new attribute called `serializeNull` is added to the `@Json` annotation. When `serializeNull = false` is set, Kotlin default values will be ignored during parsing. 

Tests and Documentation are included. 

This feature was requested in https://github.com/cbeust/klaxon/issues/253#issuecomment-525353792 (and I would like it, too). 

A remaining question: What about the performance hit due to additional checks during parsing/serialization? Should I benchmark? Is it likely to be relevant? What is your stance regarding performance?