### PR TITLE
Fix unexpected exceptions

### DIFF
--- a/klaxon/src/main/kotlin/com/beust/klaxon/KlaxonParser.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/KlaxonParser.kt
@@ -136,7 +136,10 @@ internal class KlaxonParser(
                 VALUE_TYPE.tokenType, { world: World, token: Token ->
                 with(world) {
                     popStatus()
-                    val key = popValue() as String
+                    val key = popValue()
+                    if (key !is String) {
+                        throw KlaxonException("Object keys must be strings, got: $key")
+                    }
                     parent = getFirstObject()
                     parent[key] = (token as Value<*>).value
                     status = peekStatus()
@@ -148,7 +151,10 @@ internal class KlaxonParser(
                 LEFT_BRACKET.tokenType, { world: World, _: Token ->
                 with(world) {
                     popStatus()
-                    val key = popValue() as String
+                    val key = popValue()
+                    if (key !is String) {
+                        throw KlaxonException("Object keys must be strings, got: $key")
+                    }
                     parent = getFirstObject()
                     val newArray = JsonArray<Any>()
                     parent[key] = newArray
@@ -160,7 +166,10 @@ internal class KlaxonParser(
                 LEFT_BRACE.tokenType, { world: World, _: Token ->
                 with(world) {
                     popStatus()
-                    val key = popValue() as String
+                    val key = popValue()
+                    if (key !is String) {
+                        throw KlaxonException("Object keys must be strings, got: $key")
+                    }
                     parent = getFirstObject()
                     val newObject = JsonObject()
                     parent[key] = newObject

--- a/klaxon/src/main/kotlin/com/beust/klaxon/Lexer.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/Lexer.kt
@@ -126,7 +126,11 @@ class Lexer(passedReader: Reader, val lenient: Boolean = false): Iterator<Token>
                                     throw KlaxonException("EOF reached in unicode char after: u$unicodeChar")
                                 }
 
-                                val intValue = java.lang.Integer.parseInt(unicodeChar.toString(), 16)
+                                val intValue = try {
+                                    java.lang.Integer.parseInt(unicodeChar.toString(), 16)
+                                } catch(e: NumberFormatException) {
+                                    throw KlaxonException("Failed to parse unicode char: u$unicodeChar")
+                                }
                                 currentValue.append(intValue.toChar())
                             }
                             else -> currentValue.append(c)

--- a/klaxon/src/main/kotlin/com/beust/klaxon/Lexer.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/Lexer.kt
@@ -165,7 +165,7 @@ class Lexer(passedReader: Reader, val lenient: Boolean = false): Iterator<Token>
         } else if (!isDone) {
             while (isValueLetter(c)) {
                 currentValue.append(c)
-                if (! isValueLetter(peekChar())) {
+                if (isDone || !isValueLetter(peekChar())) {
                     break
                 } else {
                     c = nextChar()

--- a/klaxon/src/main/kotlin/com/beust/klaxon/Lexer.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/Lexer.kt
@@ -116,10 +116,15 @@ class Lexer(passedReader: Reader, val lenient: Boolean = false): Iterator<Token>
                             't' -> currentValue.append("\t")
                             'u' -> {
                                 val unicodeChar = StringBuilder(4)
-                                    .append(nextChar())
-                                    .append(nextChar())
-                                    .append(nextChar())
-                                    .append(nextChar())
+                                try {
+                                    unicodeChar
+                                        .append(nextChar())
+                                        .append(nextChar())
+                                        .append(nextChar())
+                                        .append(nextChar())
+                                } catch(_: IllegalStateException) {
+                                    throw KlaxonException("EOF reached in unicode char after: u$unicodeChar")
+                                }
 
                                 val intValue = java.lang.Integer.parseInt(unicodeChar.toString(), 16)
                                 currentValue.append(intValue.toChar())

--- a/klaxon/src/test/kotlin/com/beust/klaxon/JazzerTest.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/JazzerTest.kt
@@ -32,4 +32,10 @@ class JazzerTest {
         val json = "\"\\u"
         Parser.default().parse(StringBuilder(json))
     }
+
+    @Test(expectedExceptions = [KlaxonException::class])
+    fun nonNumericUnicodeEscape() {
+        val json = "\"\\u\\\\{["
+        Parser.default().parse(StringBuilder(json))
+    }
 }

--- a/klaxon/src/test/kotlin/com/beust/klaxon/JazzerTest.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/JazzerTest.kt
@@ -26,4 +26,10 @@ class JazzerTest {
         val json = "{0\"\""
         Parser.default().parse(StringBuilder(json))
     }
+
+    @Test(expectedExceptions = [KlaxonException::class])
+    fun incompleteUnicodeEscape() {
+        val json = "\"\\u"
+        Parser.default().parse(StringBuilder(json))
+    }
 }

--- a/klaxon/src/test/kotlin/com/beust/klaxon/JazzerTest.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/JazzerTest.kt
@@ -8,4 +8,22 @@ class JazzerTest {
         val json = "0r"
         Parser.default().parse(StringBuilder(json))
     }
+
+    @Test(expectedExceptions = [KlaxonException::class])
+    fun numericKeyAndObject() {
+        val json = "{1{"
+        Parser.default().parse(StringBuilder(json))
+    }
+
+    @Test(expectedExceptions = [KlaxonException::class])
+    fun numericKeyAndArray() {
+        val json = "{3["
+        Parser.default().parse(StringBuilder(json))
+    }
+
+    @Test(expectedExceptions = [KlaxonException::class])
+    fun numericKeyAndString() {
+        val json = "{0\"\""
+        Parser.default().parse(StringBuilder(json))
+    }
 }

--- a/klaxon/src/test/kotlin/com/beust/klaxon/JazzerTest.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/JazzerTest.kt
@@ -1,0 +1,11 @@
+package com.beust.klaxon
+
+import org.testng.annotations.Test
+
+class JazzerTest {
+    @Test(expectedExceptions = [KlaxonException::class])
+    fun characterInNumericLiteral() {
+        val json = "0r"
+        Parser.default().parse(StringBuilder(json))
+    }
+}


### PR DESCRIPTION
I ran the JVM fuzzer [Jazzer](https://github.com/CodeIntelligenceTesting/jazzer) on Klaxon's default JSON parser and got four distinct crashes with exceptions not derived from `KlaxonException`.

Every commit in this PR addresses the root cause of one these crashes and adds a test case with the respective Jazzer finding.