### PR TITLE
Fix of toJsonObject

### DIFF
--- a/klaxon/src/main/kotlin/com/beust/klaxon/JsonValue.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/JsonValue.kt
@@ -5,7 +5,7 @@ import java.lang.reflect.Type
 import java.math.BigDecimal
 import java.math.BigInteger
 import kotlin.reflect.KProperty
-import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.memberProperties
 
 /**
  * Variant class that encapsulates one JSON value. Only exactly one of the property fields defined in the
@@ -187,7 +187,7 @@ class JsonValue constructor(value: Any?,
 
         private fun propertiesAndValues(obj: Any): Map<KProperty<*>, Any?> {
             val result = hashMapOf<KProperty<*>, Any?>()
-            obj::class.declaredMemberProperties
+            obj::class.memberProperties
 //                    .filter { it.visibility != KVisibility.PRIVATE && it.isAccessible }
 //            obj.javaClass.declaredFields
                     .forEach { property ->

--- a/src/test/kotlin/com/beust/klaxon/KlaxonTest.kt
+++ b/src/test/kotlin/com/beust/klaxon/KlaxonTest.kt
@@ -512,10 +512,13 @@ abstract class KlaxonBaseTest {
         assertThat(barImpl?.id).isEqualTo("id123")
     }
 
+    open class Person(val name: String, val age: Int)
+
     fun convertToJsonObjectTest() {
-        data class Employee(val name: String, val age: Int)
-        val jo = Klaxon().toJsonObject(Employee("Joe", 24))
+        class Employee(name: String, age: Int, val salary: Float) : Person(name, age)
+        val jo = Klaxon().toJsonObject(Employee("Joe", 24, 5_600.87f))
         assertThat(jo["age"]).isEqualTo("24")
         assertThat(jo["name"]).isEqualTo("\"Joe\"")
+        assertThat(jo["salary"]).isEqualTo("5600.87")
     }
 }


### PR DESCRIPTION
Fix and test update for toJsonObject-method.
toJsonObject previously did not include parent class members. The update ensures that members of the parent class are included in the JsonObject.