### PR TITLE
#344 Add instance-wide settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,29 @@ println(Klaxon().toJsonString(Data(null)))
 If `serializeNull` is false, the Kotlin default values for this property will be ignored during parsing. 
 Instead, if the property is absent in the JSON, the value will default to `null`.
 
+
+If you don't want to apply this option to every attribute, you can also set it as an instance-wide setting for Klaxon:
+```kotlin
+val settings = KlaxonSettings(serializeNull = false)
+```
+
+This saves you the hassle of setting these attributes onto every single field.
+
+```kotlin
+data class User(
+    val username: String, val email: String, // mandatory
+    val phone: String?, val fax: String?, val age: Int? // optional
+)
+
+Klaxon(settings)
+  .toJsonString(User("user", "user@example.org", null, null, null))
+
+// displays {}
+```
+
+You may still set settings with the `@Json` annotation onto specific fields.
+They will take precedence over global settings of the Klaxon instance.
+
 ### Renaming fields
 
 On top of using the `@Json(name=...)` annotation to rename fields, you can implement a field renamer yourself that

--- a/klaxon/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
@@ -78,7 +78,13 @@ class DefaultConverter(private val klaxon: Klaxon, private val allPaths: HashMap
                 val properties = Annotations.findNonIgnoredProperties(value::class, klaxon.propertyStrategies)
                 properties.forEach { prop ->
                     val getValue = prop.getter.call(value)
-                    if (Annotations.findJsonAnnotation(value::class, prop.name)?.serializeNull != false || getValue != null) {
+                    val getAnnotation = Annotations.findJsonAnnotation(value::class, prop.name)
+
+                    // Use instance settings only when no local settings exist
+                    if (getValue != null
+                         || (getAnnotation?.serializeNull == true) // Local settings have precedence to instance settings
+                         || (getAnnotation == null && klaxon.instanceSettings?.serializeNull != false)
+                    ) {
                             val jsonValue = klaxon.toJsonString(getValue, prop)
                             val fieldName = Annotations.retrieveJsonFieldName(klaxon, value::class, prop)
                             valueList.add("\"$fieldName\" : $jsonValue")

--- a/klaxon/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/DefaultConverter.kt
@@ -82,8 +82,8 @@ class DefaultConverter(private val klaxon: Klaxon, private val allPaths: HashMap
 
                     // Use instance settings only when no local settings exist
                     if (getValue != null
-                         || (getAnnotation?.serializeNull == true) // Local settings have precedence to instance settings
-                         || (getAnnotation == null && klaxon.instanceSettings?.serializeNull != false)
+                        || (getAnnotation?.serializeNull == true) // Local settings have precedence to instance settings
+                        || (getAnnotation == null && klaxon.instanceSettings.serializeNull)
                     ) {
                             val jsonValue = klaxon.toJsonString(getValue, prop)
                             val fieldName = Annotations.retrieveJsonFieldName(klaxon, value::class, prop)

--- a/klaxon/src/main/kotlin/com/beust/klaxon/JsonObjectConverter.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/JsonObjectConverter.kt
@@ -207,7 +207,10 @@ class JsonObjectConverter(private val klaxon: Klaxon, private val allPaths: Hash
                             .fromJson(JsonValue(jValue, prop.returnType.javaType,
                                     kType, klaxon))
                     result[prop.name] = convertedValue
-                } else if (jsonAnnotation?.serializeNull == false && prop.returnType.isMarkedNullable) {
+                } else if (prop.returnType.isMarkedNullable
+                    && ((jsonAnnotation?.serializeNull == false) // Local settings have precedence to instance settings
+                    || (jsonAnnotation == null && !klaxon.instanceSettings.serializeNull))
+                ) {
                     // provide a default value of null, overriding Kotlin default
                     result[prop.name] = null
                 } else {

--- a/klaxon/src/main/kotlin/com/beust/klaxon/Klaxon.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/Klaxon.kt
@@ -14,7 +14,7 @@ import kotlin.reflect.jvm.javaMethod
 import kotlin.reflect.jvm.javaType
 
 class Klaxon(
-    val instanceSettings: KlaxonSettings? = null
+    val instanceSettings: KlaxonSettings = KlaxonSettings()
 ) : ConverterFinder {
     /**
      * Parse a JsonReader into a JsonObject.

--- a/klaxon/src/main/kotlin/com/beust/klaxon/Klaxon.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/Klaxon.kt
@@ -13,7 +13,9 @@ import kotlin.reflect.jvm.javaField
 import kotlin.reflect.jvm.javaMethod
 import kotlin.reflect.jvm.javaType
 
-class Klaxon : ConverterFinder {
+class Klaxon(
+    val instanceSettings: KlaxonSettings? = null
+) : ConverterFinder {
     /**
      * Parse a JsonReader into a JsonObject.
      */

--- a/klaxon/src/main/kotlin/com/beust/klaxon/KlaxonSettings.kt
+++ b/klaxon/src/main/kotlin/com/beust/klaxon/KlaxonSettings.kt
@@ -1,0 +1,10 @@
+package com.beust.klaxon
+
+data class KlaxonSettings(
+
+    /**
+     * If false, property will be absent in JSON when value is null.
+     * If true, property will be present in JSON with value null.
+     */
+    val serializeNull: Boolean = true
+)

--- a/klaxon/src/test/kotlin/com/beust/klaxon/InstanceSettingsTest.kt
+++ b/klaxon/src/test/kotlin/com/beust/klaxon/InstanceSettingsTest.kt
@@ -1,0 +1,88 @@
+package com.beust.klaxon
+
+import org.testng.annotations.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+@Test
+class InstanceSettingsTest {
+
+    @Suppress("unused")
+    class UnannotatedGeolocationCoordinates(
+        val latitude: Int,
+        val longitude: Int,
+        val speed: Int? // nullable field
+    )
+
+    @Suppress("unused")
+    class NoNullAnnotatedGeolocationCoordinates(
+        val latitude: Int,
+        val longitude: Int,
+        @Json(serializeNull = false) val speed: Int? // nullable field
+    )
+
+    @Suppress("unused")
+    class NullAnnotatedGeolocationCoordinates(
+        val latitude: Int,
+        val longitude: Int,
+        @Json(serializeNull = true) val speed: Int? // nullable field
+    )
+
+    private val unannotatedCoordinates = UnannotatedGeolocationCoordinates(1, 2, null)
+    private val noNullCoordinates = NoNullAnnotatedGeolocationCoordinates(1, 2, null)
+    private val nullCoordinates = NullAnnotatedGeolocationCoordinates(1, 2, null)
+
+    // Defaults & single-type settings
+
+    @Test
+    fun defaultSerialization() {
+        val klaxon = Klaxon()
+        val json = klaxon.toJsonString(unannotatedCoordinates)
+        assertContains(json, "null") // {"latitude" : 1, "longitude" : 2, "speed" : null}
+    }
+
+    @Test // no local settings, instance serializeNull = true -> null
+    fun instanceSettingsNullSerialization() {
+        val klaxon = Klaxon(instanceSettings = KlaxonSettings(serializeNull = true))
+        val json = klaxon.toJsonString(unannotatedCoordinates)
+        assertContains(json, "null") // {"latitude" : 1, "longitude" : 2, "speed" : null}
+    }
+
+    @Test // no local settings, instance serializeNull = false -> no null
+    fun instanceSettingsNoNullSerialization() {
+        val klaxon = Klaxon(KlaxonSettings(serializeNull = false))
+        val json = klaxon.toJsonString(unannotatedCoordinates)
+        assertFalse { json.contains("null") } // {"latitude" : 1, "longitude" : 2}
+    }
+
+    @Test // local serializeNull = false, no instance settings -> no null
+    fun localSettingsNoNullSerialization() {
+        val klaxon = Klaxon()
+        val json = klaxon.toJsonString(noNullCoordinates)
+        assertFalse { json.contains("null") } // {"latitude" : 1, "longitude" : 2}
+    }
+
+    @Test // local serializeNull = true, no instance settings -> null
+    fun localSettingsNullSerialization() {
+        val klaxon = Klaxon()
+        val json = klaxon.toJsonString(nullCoordinates)
+        assertContains(json, "null") // {"latitude" : 1, "longitude" : 2, "speed" : null}
+    }
+
+    //
+    // Mixed tests
+
+    @Test // local serializeNull = true, instance serializeNull = false -> null
+    fun localNullInstanceNoNullSerialization() {
+        val klaxon = Klaxon(KlaxonSettings(serializeNull = false))
+        val json = klaxon.toJsonString(nullCoordinates)
+        assertContains(json, "null") // {"latitude" : 1, "longitude" : 2, "speed" : null}
+    }
+
+    @Test // local serializeNull = false, instance serializeNull = true -> no null
+    fun localNoNullInstanceNullSerialization() {
+        val klaxon = Klaxon(KlaxonSettings(serializeNull = true))
+        val json = klaxon.toJsonString(noNullCoordinates)
+        assertFalse { json.contains("null") } // {"latitude" : 1, "longitude" : 2}
+    }
+}


### PR DESCRIPTION
This pull request adds the ability to optionally supply settings for a Klaxon instance in the constructor. These instance wide settings complement the settings of individual attributes set with `@Json(...)`.
```kotlin
val settings = KlaxonSettings(serializeNull = false)
```

Currently, it is only implemented for `serializeNull`, however, it is simple to extend for future uses too.

This allows to e.g. write:
```kotlin
data class User(
    val username: String, val email: String, // mandatory
    val phone: String?, val fax: String?, val age: Int? // optional
)

Klaxon(settings)
  .toJsonString(User("user", "user@example.org", null, null, null))

// displays {}
```

instead of having to add these options to every attribute like this:
```kotlin
data class User(
    val username: String, val email: String, // mandatory
    @Json(serializeNull = false) val phone: String?,  // optional
    @Json(serializeNull = false) val fax: String?,  // optional
    @Json(serializeNull = false) val age: Int? // optional
)

```

The documentation was extended to illustrate this feature, and a test class was added to check its functionality.

Fixes #344