### PR TITLE
Replace Bintray with MavenCentral

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,51 @@ dependencies {
 }
 ```
 
+## Developer setup
+
+Follow these steps to get the project running locally for development:
+
+- **Prerequisites:**
+    - JDK 8 or 11 installed and `JAVA_HOME` set.
+    - Git
+- **Clone the repo:**
+
+```bash
+git clone https://github.com/cbeust/klaxon.git
+cd klaxon
+```
+
+- **Build the project:**
+
+Unix/macOS:
+```bash
+./gradlew build
+```
+
+Windows (PowerShell/CMD):
+```powershell
+.\gradlew.bat build
+```
+
+- **Run tests:**
+
+```bash
+./gradlew test
+```
+
+- **Run a single test class:**
+
+```bash
+./gradlew test --tests com.beust.klaxon.BindingTest
+```
+
+- **Import into IDE:** Import the project as a Gradle project in IntelliJ IDEA (use the Gradle wrapper). Enable auto-import for Gradle changes.
+
+- **Useful module/task shortcuts:**
+    - Assemble JARs: `./gradlew assemble`
+    - Run aggregate task: `./gradlew publishToMavenLocal`
+    - Generate signature files: `./gradlew signCustomPublication`
+
 ## Community
 
 Join the [`#klaxon` Slack channel](https://kotlinlang.slack.com/messages/C90AVCDQU/).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ allprojects {
     version = "1.0"
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/klaxon/build.gradle.kts
+++ b/klaxon/build.gradle.kts
@@ -22,7 +22,6 @@ allprojects {
 plugins {
     `maven-publish`
     signing
-    id("com.jfrog.bintray") version "1.8.3" // Don't use 1.8.4, crash when publishing
     kotlin("jvm")
 }
 
@@ -36,33 +35,6 @@ dependencies {
 
     listOf("stdlib", "reflect").forEach {
         implementation(kotlin(it))
-    }
-}
-
-//
-// Releases:
-// ./gradlew bintrayUpload (to JCenter)
-// ./gradlew publish (to Sonatype, then go to https://oss.sonatype.org/index.html#stagingRepositories to publish)
-//
-
-bintray {
-    user = project.findProperty("bintrayUser")?.toString() ?: System.getenv("BINTRAY_USER")
-    key = project.findProperty("bintrayApiKey")?.toString() ?: System.getenv("BINTRAY_API_KEY")
-    dryRun = false
-    publish = false
-
-    setPublications("custom")
-
-    with(pkg) {
-        repo = "maven"
-        name = This.artifactId
-        with(version) {
-            name = This.version
-            desc = This.description
-            with(gpg) {
-                sign = true
-            }
-        }
     }
 }
 
@@ -149,8 +121,10 @@ tasks.register("publishSnapshotOnly") {
 }
 
 // Sign with ./gradlew signCustomPublication
-with(signing) {
-    sign(publishing.publications.getByName("custom"))
+signing {
+   val isRelease = project.hasProperty("release")
+   isRequired = isRelease 
+   sign(publishing.publications["custom"])
 }
 
 tasks.test {


### PR DESCRIPTION
JFrog has shut down Bintray and JCenter, which requires migrating our publishing pipeline to Maven Central. While Klaxon already uses Maven Central for dependencies, this PR removes the defunct Bintray upload tasks and let maven publish plugins handle it.

This change would fix Gradle errors caused by the missing Bintray library. Additionally, the README has been updated with first-time developer setup instructions to assist with GPG signing and local publishing.

Fixes - https://github.com/cbeust/klaxon/issues/369